### PR TITLE
fix(navigation): restore reliable drawer navigation and new instance flow

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/navigation/NavigationManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/navigation/NavigationManager.kt
@@ -54,7 +54,7 @@ class NavigationManager(
 
     fun openNewInstanceScreen(type: InstanceType) {
         openDrawer()
-//        _selectedDrawerTab.value = TabItem.SETTINGS
+        _selectedDrawerTab.value = TabItem.SETTINGS
         settings().navigateTo(SettingsScreen.AddInstance(type))
     }
 

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/navigation/NavigationDrawerButton.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/navigation/NavigationDrawerButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.runtime.Composable
+import com.dnfapps.arrmatey.compose.TabItem
 import com.dnfapps.arrmatey.navigation.NavigationManager
 import org.koin.compose.koinInject
 
@@ -14,7 +15,10 @@ fun NavigationDrawerButton(returnToHome: Boolean = false) {
     val navigationManager: NavigationManager = koinInject()
     IconButton(onClick = {
 //        navigationManager.openDrawer()
-        navigationManager.setDrawerOpen(!returnToHome)
+        val isOpen = !returnToHome
+        navigationManager.setDrawerOpen(isOpen)
+        val tab = if (isOpen) TabItem.SETTINGS else null
+        navigationManager.setSelectedDrawerTab(tab)
     } ) {
         if (returnToHome) {
             Icon(Icons.AutoMirrored.Default.ArrowBack, null)

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrConfigurationScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrConfigurationScreen.kt
@@ -114,7 +114,8 @@ fun ArrConfigurationScreen(
                 endpointError -> mokoString(MR.strings.invalid_host)
                 hasUrlConflict -> mokoString(MR.strings.instance_url_exists)
                 else -> null
-            }
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri)
         )
 
         AMOutlinedTextField(

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/HomeScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/HomeScreen.kt
@@ -75,12 +75,12 @@ fun HomeScreen(
         pagerState.scrollToPage(selectedTab.ordinal)
     }
 
-    LaunchedEffect(drawerState.currentValue) {
-        val isInternalOpen = drawerState.currentValue == DrawerValue.Open
-        if (drawerExtendedState != isInternalOpen) {
-            navigationManager.setDrawerOpen(isInternalOpen)
-        }
-    }
+//    LaunchedEffect(drawerState.currentValue) {
+//        val isInternalOpen = drawerState.currentValue == DrawerValue.Open
+//        if (drawerExtendedState != isInternalOpen) {
+//            navigationManager.setDrawerOpen(isInternalOpen)
+//        }
+//    }
 
     LaunchedEffect(drawerExtendedState) {
 //        if (drawerExtendedState && drawerState.isClosed) {
@@ -109,6 +109,7 @@ fun HomeScreen(
                         icon = { Icon(Icons.Default.Home, null) },
                         onClick = {
                             scope.launch {
+                                navigationManager.setDrawerOpen(false)
                                 navigationManager.setSelectedDrawerTab(null)
                                 drawerState.close()
                             }
@@ -122,6 +123,7 @@ fun HomeScreen(
                         label = { Text(mokoString(MR.strings.settings)) },
                         onClick = {
                             scope.launch {
+                                navigationManager.setDrawerOpen(true)
                                 navigationManager.setSelectedDrawerTab(TabItem.SETTINGS)
                                 drawerState.close()
                             }

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/SettingsTab.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/SettingsTab.kt
@@ -1,8 +1,12 @@
 package com.dnfapps.arrmatey.ui.tabs
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation3.runtime.entryProvider
 import androidx.navigation3.ui.NavDisplay
+import com.dnfapps.arrmatey.database.InstanceRepository
 import com.dnfapps.arrmatey.navigation.NavigationManager
 import com.dnfapps.arrmatey.navigation.SettingsNavigation
 import com.dnfapps.arrmatey.navigation.SettingsScreen
@@ -15,8 +19,16 @@ import org.koin.compose.koinInject
 @Composable
 fun SettingsTabNavHost(
     navigationManager: NavigationManager = koinInject(),
+    instanceRepository: InstanceRepository = koinInject(),
     navigation: SettingsNavigation = navigationManager.settings()
 ) {
+    val instances by instanceRepository.allInstancesFlow.collectAsStateWithLifecycle()
+
+    BackHandler(enabled = navigation.backStack.size <= 1 && instances.isNotEmpty()) {
+        navigationManager.setDrawerOpen(false)
+        navigationManager.setSelectedDrawerTab(null)
+    }
+
     NavDisplay(
         backStack = navigation.backStack,
         onBack = { navigation.popBackStack() },


### PR DESCRIPTION
## Summary
This PR fixes navigation issues where the "Settings" item in the drawer and the "New Instance" button would sometimes become unresponsive or fail to trigger navigation after backing out of a screen. Also, fixes an issue where a space was inserted after `https:` or `http:` depending on keyboard.
## Problem
The navigation logic was relying too heavily on side effects from `drawerExpandedState` changes. This caused race conditions where:
1.  Backing out of Settings to Home left the state in a way that subsequent clicks on "Settings" were ignored.
2.  Clicking "New Instance" (on an empty library screen) opened the drawer but didn't switch the active tab to the form.
## Changes
- **NavigationManager.kt**: Restored explicit `setSelectedDrawerTab` call in `openNewInstanceScreen` to ensure the tab switches immediately.
- **HomeScreen.kt**: Added explicit `navigationManager.setSelectedDrawerTab(...)` calls to the drawer items (Home/Settings) to guarantee navigation intent is registered.
- **NavigationDrawerButton.kt**: Updated the button to handle tab selection state explicitly when toggling the drawer.
- **ArrConfigurationScreen.kt**: Added `KeyboardOptions(keyboardType = KeyboardType.Uri)` to the instance URL field for better UX (minor fix).
## Verification
- Validated that clicking "Settings" -> Back -> "Settings" now works consistently.
- Validated that clicking "Add Instance" (or "New Instance") now correctly opens the drawer *and* navigates to the form.
## Note
These fixes are for android only. Due to system constraints, i could not test ios app