### PR TITLE
fix typo in the word 'Premiere'

### DIFF
--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -32,7 +32,7 @@ ArrMatey is an all-in-one mobile companion for your home server media stack. Sup
 <li>
 <ul>View upcoming episodes, movie, and album releases</ul>
 <ul>Switch between list and month views</ul>
-<ul>Filter by content type, monitored status, premiers/finales</ul>
+<ul>Filter by content type, monitored status, premieres/finales</ul>
 <ul>Scroll-to-today for easy navigation</ul>
 </li>
 

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -317,8 +317,8 @@
     <string name="today">Today</string>
     <string name="tomorrow">Tomorrow</string>
     <string name="yesterday">Yesterday</string>
-    <string name="premier">Premier</string>
-    <string name="premiers_only">Premiers</string>
+    <string name="premier">Premiere</string>
+    <string name="premiers_only">Premieres</string>
     <string name="finales_only">Finales</string>
     <string name="additional_episodes_count">+%1$d more</string>
     <string name="schedule">Schedule</string>


### PR DESCRIPTION
Just a small typo fix for the use of the word ['Premiere'](https://dictionary.cambridge.org/dictionary/english/premiere).

There are also references in functions and variables in the code, but I only changed the strings, as I can't build the app for the moment (to make sure I don't break anything). I could do that too if you want but it's pretty simple anyway.