### PR TITLE
Fix crash when adding artist in lidarr

### DIFF
--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/LidarrClient.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/LidarrClient.kt
@@ -16,7 +16,6 @@ import com.dnfapps.arrmatey.arr.api.model.LidarrTrack
 import com.dnfapps.arrmatey.arr.api.model.LidarrTrackFile
 import com.dnfapps.arrmatey.arr.api.model.MonitoredResponse
 import com.dnfapps.arrmatey.arr.api.model.ReleaseParams
-import com.dnfapps.arrmatey.arr.api.model.RootFolder
 import com.dnfapps.arrmatey.client.NetworkResult
 import com.dnfapps.arrmatey.instances.model.Instance
 import io.ktor.client.HttpClient
@@ -111,9 +110,6 @@ class LidarrClient(
             "pageSize" to pageSize,
             "albumId" to id
         )).map { it.records }
-
-    override suspend fun getRootFolders(): NetworkResult<List<RootFolder>> =
-        get("rootfolders")
 
     override suspend fun getCalendar(
         start: LocalDate,


### PR DESCRIPTION
Fix crash when adding artist in lidarr; Lidarr's endpoint is `rootfolder` (the base setting) not `rootfolders`

Fixes https://github.com/owenlejeune/ArrMatey/issues/92
