### PR TITLE
Check api not required or key is not blank

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrConfigurationScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrConfigurationScreen.kt
@@ -247,7 +247,8 @@ fun ArrConfigurationScreen(
 
         TestConnectionSection(
             isTesting = isTesting,
-            testButtonEnabled = !isTesting && apiEndpoint.isNotBlank() && apiKey.isNotBlank(),
+            testButtonEnabled = !isTesting && apiEndpoint.isNotBlank() &&
+                    (uiState.noApiKeyRequired || apiKey.isNotBlank()),
             testResult = testResult,
             onTestConnection = onTestConnection
         )
@@ -712,7 +713,7 @@ fun LocalNetworkArea(
                             onClick = onTestLocalConnection,
                             enabled = !uiState.localTesting &&
                                     uiState.localNetworkUrl.isNotBlank() &&
-                                    uiState.apiKey.isNotBlank(),
+                                    (uiState.noApiKeyRequired || uiState.apiKey.isNotBlank()),
                         ) {
                             if (uiState.localTesting) {
                                 CircularProgressIndicator(

--- a/iosApp/iosApp/Views/Components/ArrConfigurationView.swift
+++ b/iosApp/iosApp/Views/Components/ArrConfigurationView.swift
@@ -265,7 +265,7 @@ struct ArrConfigurationView: View {
                     Text(MR.strings().test.localized())
                 }
             }
-            .disabled(uiState.testing || uiState.apiEndpoint.isEmpty || uiState.apiKey.isEmpty)
+            .disabled(uiState.testing || uiState.apiEndpoint.isEmpty || (!uiState.noApiKeyRequired && uiState.apiKey.isEmpty))
             
             Spacer()
             
@@ -467,7 +467,7 @@ struct ArrConfigurationView: View {
                                 Text(MR.strings().test.localized())
                             }
                         }
-                        .disabled(uiState.localTesting || uiState.localNetworkUrl.isEmpty || uiState.localNetworkSsids.isEmpty)
+                        .disabled(uiState.localTesting || uiState.localNetworkUrl.isEmpty || (!uiState.noApiKeyRequired && uiState.apiKey.isEmpty))
                         
                         Spacer()
                         

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/viewmodel/AddInstanceViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/viewmodel/AddInstanceViewModel.kt
@@ -157,7 +157,13 @@ class AddInstanceViewModel(
 
             _uiState.update { it.copy(localTesting = true, localNetworkUrlError = false) }
 
-            val success = testNewInstanceConnectionUseCase(state.localNetworkUrl, state.apiKey, type, state.headers)
+            val success = testNewInstanceConnectionUseCase(
+                state.localNetworkUrl,
+                state.apiKey,
+                type,
+                state.headers,
+                state.noApiKeyRequired
+            )
 
             _uiState.update {
                 it.copy(


### PR DESCRIPTION
Check that api key is not required or api key is not blank, when deciding to enable the test button.

Fixed on android, and make iOS the same.

Fixes https://github.com/owenlejeune/ArrMatey/issues/98
