### PR TITLE
Use client id and item id for key for downloads

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
@@ -263,7 +263,10 @@ fun DownloadsTab(
                                 contentPadding = PaddingValues(16.dp),
                                 state = listState
                             ) {
-                                items(items = queueState.queueItems, key = { it.id }) { item ->
+                                items(
+                                    items = queueState.queueItems,
+                                    key = { "${it.client.id}:${it.id}" }
+                                ) { item ->
                                     TorrentActionsCard(
                                         item = item,
                                         showClientInfo = filterState.clientIds.size > 1,


### PR DESCRIPTION
Use the client id + item id for the key for the downloads list (instead of just item id), avoiding conflicts if you have multiple download clients.

Fixes https://github.com/owenlejeune/ArrMatey/issues/120
