### PR TITLE
Show client info on downloads if multiple clients

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
@@ -269,7 +269,7 @@ fun DownloadsTab(
                                 ) { item ->
                                     TorrentActionsCard(
                                         item = item,
-                                        showClientInfo = filterState.clientIds.size > 1,
+                                        showClientInfo = downloadClientState.downloadClients.size > 1,
                                         onPause = { viewModel.pauseDownload(item.id) },
                                         onResume = { viewModel.resumeDownload(item.id) },
                                         onDelete = { deleteTarget = item }

--- a/iosApp/iosApp/Views/Tabs/DownloadsTab.swift
+++ b/iosApp/iosApp/Views/Tabs/DownloadsTab.swift
@@ -117,7 +117,7 @@ struct DownloadsTab: View {
                     ForEach(viewModel.downloadQueueState.queueItems, id: \.id) { item in
                         DownloadQueueItemView(
                             item: item,
-                            showClientInfo: viewModel.filterState.clientIds.count > 1
+                            showClientInfo: clientsViewModel.downloadClientsState.downloadClients.count > 1
                         )
                         .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
                         .listRowSeparator(.hidden)


### PR DESCRIPTION
Show client info on downloads if multiple clients.

Fixes https://github.com/owenlejeune/ArrMatey/issues/141

Tested on Android; iOS is untested.
