### PR TITLE
Put available and total together on the left side

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/MediaList.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/MediaList.kt
@@ -329,16 +329,12 @@ private fun SeriesDetails(
     Text(statusStr, color = contentColor, fontSize = 14.sp, lineHeight = 18.sp)
 
     if (item.id != null) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 1.dp)
-        ) {
-            Text(text = item.episodeFileCount.toString(), fontSize = 12.sp, color = contentColor)
-            Text(text = "/${item.episodeCount}", fontSize = 12.sp, color = contentColor)
-        }
+        Text(
+            text = "${item.episodeFileCount}/${item.episodeCount}",
+            fontSize = 12.sp,
+            color = contentColor,
+            modifier = Modifier.padding(top = 8.dp, bottom = 1.dp)
+        )
         LinearProgressIndicator(
             progress = { item.statusProgress },
             modifier = Modifier
@@ -411,16 +407,12 @@ private fun ArtistDetails(
     Text(statusStr, color = contentColor, fontSize = 14.sp, lineHeight = 18.sp)
 
     if (item.id != null) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 1.dp)
-        ) {
-            Text(text = item.trackFileCount.toString(), fontSize = 12.sp, color = contentColor)
-            Text(text = "/${item.trackCount}", fontSize = 12.sp, color = contentColor)
-        }
+        Text(
+            text = "${item.trackFileCount}/${item.trackCount}",
+            fontSize = 12.sp,
+            color = contentColor,
+            modifier = Modifier.padding(top = 8.dp, bottom = 1.dp)
+        )
         LinearProgressIndicator(
             progress = { item.statusProgress },
             color = if (isActive) ArrPurple else item.statusColor,
@@ -455,16 +447,12 @@ private fun AuthorDetails(
     Text(statusStr, color = contentColor, fontSize = 14.sp, lineHeight = 18.sp)
 
     if (item.id != null) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.SpaceBetween,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(top = 8.dp, bottom = 1.dp)
-        ) {
-            Text(text = item.bookFileCount.toString(), fontSize = 12.sp, color = contentColor)
-            Text(text = "/${item.bookCount}", fontSize = 12.sp, color = contentColor)
-        }
+        Text(
+            text = "${item.bookFileCount}/${item.bookCount}",
+            fontSize = 12.sp,
+            color = contentColor,
+            modifier = Modifier.padding(top = 8.dp, bottom = 1.dp)
+        )
         LinearProgressIndicator(
             progress = { item.statusProgress },
             color = if (isActive) ArrPurple else item.statusColor,

--- a/iosApp/iosApp/Views/Components/ArtistDetailsView.swift
+++ b/iosApp/iosApp/Views/Components/ArtistDetailsView.swift
@@ -70,16 +70,9 @@ struct ArtistDetailsView: View {
             
             Spacer()
             
-            HStack {
-                Text("\(item.trackFileCount)")
-                    .font(.system(size: 12))
-                
-                Spacer()
-                
-                Text("/\(item.trackCount)")
-                    .font(.system(size: 12))
-            }
-            .padding(.bottom, 1)
+            Text("\(item.trackFileCount)/\(item.trackCount)")
+                .font(.system(size: 12))
+                .padding(.bottom, 1)
             
             ProgressView(value: item.statusProgress)
                 .progressViewStyle(LinearProgressViewStyle(tint: progressColor))

--- a/iosApp/iosApp/Views/Components/AuthorDetailsView.swift
+++ b/iosApp/iosApp/Views/Components/AuthorDetailsView.swift
@@ -70,16 +70,9 @@ struct AuthorDetailsView: View {
             
             Spacer()
             
-            HStack {
-                Text("\(item.bookFileCount)")
-                    .font(.system(size: 12))
-                
-                Spacer()
-                
-                Text("/\(item.bookCount)")
-                    .font(.system(size: 12))
-            }
-            .padding(.bottom, 1)
+            Text("\(item.bookFileCount)/\(item.bookCount)")
+                .font(.system(size: 12))
+                .padding(.bottom, 1)
             
             ProgressView(value: item.statusProgress)
                 .progressViewStyle(LinearProgressViewStyle(tint: progressColor))

--- a/iosApp/iosApp/Views/Components/SeriesDetailsView.swift
+++ b/iosApp/iosApp/Views/Components/SeriesDetailsView.swift
@@ -73,17 +73,10 @@ struct SeriesDetailsView: View {
                 .font(.system(size: 14))
                 .lineSpacing(4)
             
-            HStack {
-                Text("\(item.episodeFileCount)")
-                    .font(.system(size: 12))
-                
-                Spacer()
-                
-                Text("/\(item.episodeCount)")
-                    .font(.system(size: 12))
-            }
-            .padding(.bottom, 1)
-            .padding(.top, 4)
+            Text("\(item.episodeFileCount)/\(item.episodeCount)")
+                .font(.system(size: 12))
+                .padding(.bottom, 1)
+                .padding(.top, 4)
             
             ProgressView(value: item.statusProgress)
                 .progressViewStyle(LinearProgressViewStyle(tint: progressColor))


### PR DESCRIPTION
Put available and total together, on the left side, for series, music (artist), and books (author).

Fixes https://github.com/owenlejeune/ArrMatey/issues/145

I tested on android but iOS is untested.