### PR TITLE
Fix delete on downloads tab add error logging and display

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
@@ -52,6 +52,8 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.SwipeToDismissBox
 import androidx.compose.material3.SwipeToDismissBoxValue
 import androidx.compose.material3.Text
@@ -90,6 +92,7 @@ import com.dnfapps.arrmatey.downloadclient.viewmodel.DownloadQueueViewModel
 import com.dnfapps.arrmatey.entensions.ArrowDown
 import com.dnfapps.arrmatey.entensions.ArrowUp
 import com.dnfapps.arrmatey.entensions.Bullet
+import com.dnfapps.arrmatey.entensions.showErrorImmediately
 import com.dnfapps.arrmatey.navigation.NavigationManager
 import com.dnfapps.arrmatey.shared.MR
 import com.dnfapps.arrmatey.ui.components.ArrAppBarWithSearch
@@ -133,6 +136,9 @@ fun DownloadsTab(
     var deleteTarget by remember { mutableStateOf<DownloadItem?>(null) }
     var bulkDeleteTarget by remember { mutableStateOf(false) }
 
+    val snackbarHostState = remember { SnackbarHostState() }
+    val genericErrorMessage = mokoString(MR.strings.error)
+
     val textFieldState = rememberTextFieldState()
 
     val availableTags = remember(queueState.queueItems) {
@@ -144,11 +150,18 @@ fun DownloadsTab(
     }
 
     LaunchedEffect(commandState) {
-        when (commandState) {
-            is DownloadClientCommandState.Success,
+        when (val state = commandState) {
+            is DownloadClientCommandState.Success -> {
+                deleteTarget = null
+                bulkDeleteTarget = false
+                viewModel.resetCommandState()
+            }
             is DownloadClientCommandState.Error -> {
                 deleteTarget = null
                 bulkDeleteTarget = false
+                snackbarHostState.showErrorImmediately(
+                    message = state.message ?: genericErrorMessage
+                )
                 viewModel.resetCommandState()
             }
             else -> {}
@@ -159,6 +172,7 @@ fun DownloadsTab(
 
     Scaffold(
         modifier = Modifier.fillMaxSize(),
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             if (isInSelectionMode) {
                 SelectionTopBar(

--- a/iosApp/iosApp/ViewModel/DownloadQueueViewModelS.swift
+++ b/iosApp/iosApp/ViewModel/DownloadQueueViewModelS.swift
@@ -16,6 +16,7 @@ class DownloadQueueViewModelS: ObservableObject {
     @Published private(set) var commandState: DownloadClientCommandState = DownloadClientCommandStateInitial()
     @Published private(set) var isCommandLoading: Bool = false
     @Published private(set) var isCommandSuccess: Bool = false
+    @Published private(set) var isCommandError: Bool = false
     @Published private(set) var isRefreshing: Bool = true
     @Published private(set) var hasLoaded: Bool = false
     @Published private(set) var errorMessage: String? = nil
@@ -38,6 +39,7 @@ class DownloadQueueViewModelS: ObservableObject {
             owner.commandState = state
             owner.isCommandLoading = state is DownloadClientCommandStateLoading
             owner.isCommandSuccess = state is DownloadClientCommandStateSuccess
+            owner.isCommandError = state is DownloadClientCommandStateError
         }
         viewModel.isRefreshing.observeAsync(on: self) { owner, isRefreshing in
             owner.isRefreshing = isRefreshing.boolValue

--- a/iosApp/iosApp/Views/Tabs/DownloadsTab.swift
+++ b/iosApp/iosApp/Views/Tabs/DownloadsTab.swift
@@ -16,6 +16,7 @@ struct DownloadsTab: View {
     @State private var deleteId: String? = nil
     @State private var showDeleteConfirm: Bool = false
     @State private var searchQuery: String = ""
+    @State private var toastMessage: String? = nil
     
     private var searchPrompt: String {
         let count = viewModel.downloadQueueState.queueItems.count
@@ -51,6 +52,27 @@ struct DownloadsTab: View {
                 viewModel.resetCommandState()
             }
         }
+        .onChange(of: viewModel.isCommandError) { _, isError in
+            if isError {
+                let error = viewModel.commandState as? DownloadClientCommandStateError
+                toastMessage = error?.message ?? MR.strings().error.localized()
+                deleteTarget = nil
+                deleteId = nil
+                viewModel.resetCommandState()
+            }
+        }
+        .overlay(alignment: .bottom) {
+            if let message = toastMessage {
+                ToastView(message: message)
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .onAppear {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) {
+                            withAnimation { toastMessage = nil }
+                        }
+                    }
+            }
+        }
+        .animation(.easeInOut(duration: 0.3), value: toastMessage != nil)
         .confirmationDialog(
             MR.strings().delete_files.localized(),
             isPresented: $showDeleteConfirm,

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/di/Modules.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/di/Modules.kt
@@ -301,9 +301,9 @@ val useCaseModule = module {
     factory { GetSeerrTvRatingsUseCase(get()) }
     factory { ObserveDownloadClientsUseCase(get()) }
     factory { ObserveDownloadQueueUseCase(get()) }
-    factory { PauseDownloadUseCase(get()) }
-    factory { ResumeDownloadUseCase(get()) }
-    factory { DeleteDownloadUseCase(get()) }
+    factory { PauseDownloadUseCase(get(), get()) }
+    factory { ResumeDownloadUseCase(get(), get()) }
+    factory { DeleteDownloadUseCase(get(), get()) }
     factory { TestDownloadClientConnectionUseCase(get()) }
     factory { CreateDownloadClientUseCase(get()) }
     factory { DeleteDownloadClientUseCase(get()) }

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/usecase/DeleteDownloadUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/usecase/DeleteDownloadUseCase.kt
@@ -3,25 +3,37 @@ package com.dnfapps.arrmatey.downloadclient.usecase
 import com.dnfapps.arrmatey.client.NetworkResult
 import com.dnfapps.arrmatey.client.OperationStatus
 import com.dnfapps.arrmatey.downloadclient.repository.DownloadClientManager
+import dev.shivathapaa.logger.api.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class DeleteDownloadUseCase(
-    private val downloadClientManager: DownloadClientManager
+    private val downloadClientManager: DownloadClientManager,
+    private val logger: Logger
 ) {
 
-    operator fun invoke(ids: List<String>, deleteFiles: Boolean): Flow<OperationStatus> = flow {
+    operator fun invoke(
+        clientId: Long,
+        ids: List<String>,
+        deleteFiles: Boolean
+    ): Flow<OperationStatus> = flow {
         emit(OperationStatus.InProgress)
 
-        val api = downloadClientManager.getSelectedDownloadClientApiSnapshot()
+        val api = downloadClientManager.getOrCreateApi(clientId)
         if (api == null) {
-            emit(OperationStatus.Error(message = "No download client selected"))
+            logger.error { "Delete failed: no download-client API for id $clientId" }
+            emit(OperationStatus.Error(message = "Download client not available"))
             return@flow
         }
 
         when (val result = api.deleteDownload(ids, deleteFiles)) {
             is NetworkResult.Success -> emit(OperationStatus.Success("Downloads deleted"))
-            is NetworkResult.Error -> emit(OperationStatus.Error(result.code, result.message, result.cause))
+            is NetworkResult.Error -> {
+                logger.error(result.cause) {
+                    "Delete failed on client $clientId (ids=$ids): ${result.message} (code=${result.code})"
+                }
+                emit(OperationStatus.Error(result.code, result.message, result.cause))
+            }
             is NetworkResult.Loading -> emit(OperationStatus.InProgress)
         }
     }

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/usecase/PauseDownloadUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/usecase/PauseDownloadUseCase.kt
@@ -3,25 +3,33 @@ package com.dnfapps.arrmatey.downloadclient.usecase
 import com.dnfapps.arrmatey.client.NetworkResult
 import com.dnfapps.arrmatey.client.OperationStatus
 import com.dnfapps.arrmatey.downloadclient.repository.DownloadClientManager
+import dev.shivathapaa.logger.api.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class PauseDownloadUseCase(
-    private val downloadClientManager: DownloadClientManager
+    private val downloadClientManager: DownloadClientManager,
+    private val logger: Logger
 ) {
 
-    operator fun invoke(ids: List<String>): Flow<OperationStatus> = flow {
+    operator fun invoke(clientId: Long, ids: List<String>): Flow<OperationStatus> = flow {
         emit(OperationStatus.InProgress)
 
-        val api = downloadClientManager.getSelectedDownloadClientApiSnapshot()
+        val api = downloadClientManager.getOrCreateApi(clientId)
         if (api == null) {
-            emit(OperationStatus.Error(message = "No download client selected"))
+            logger.error { "Pause failed: no download-client API for id $clientId" }
+            emit(OperationStatus.Error(message = "Download client not available"))
             return@flow
         }
 
         when (val result = api.pauseDownload(ids)) {
             is NetworkResult.Success -> emit(OperationStatus.Success("Downloads paused"))
-            is NetworkResult.Error -> emit(OperationStatus.Error(result.code, result.message, result.cause))
+            is NetworkResult.Error -> {
+                logger.error(result.cause) {
+                    "Pause failed on client $clientId (ids=$ids): ${result.message} (code=${result.code})"
+                }
+                emit(OperationStatus.Error(result.code, result.message, result.cause))
+            }
             is NetworkResult.Loading -> emit(OperationStatus.InProgress)
         }
     }

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/usecase/ResumeDownloadUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/usecase/ResumeDownloadUseCase.kt
@@ -3,25 +3,33 @@ package com.dnfapps.arrmatey.downloadclient.usecase
 import com.dnfapps.arrmatey.client.NetworkResult
 import com.dnfapps.arrmatey.client.OperationStatus
 import com.dnfapps.arrmatey.downloadclient.repository.DownloadClientManager
+import dev.shivathapaa.logger.api.Logger
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 class ResumeDownloadUseCase(
-    private val downloadClientManager: DownloadClientManager
+    private val downloadClientManager: DownloadClientManager,
+    private val logger: Logger
 ) {
 
-    operator fun invoke(ids: List<String>): Flow<OperationStatus> = flow {
+    operator fun invoke(clientId: Long, ids: List<String>): Flow<OperationStatus> = flow {
         emit(OperationStatus.InProgress)
 
-        val api = downloadClientManager.getSelectedDownloadClientApiSnapshot()
+        val api = downloadClientManager.getOrCreateApi(clientId)
         if (api == null) {
-            emit(OperationStatus.Error(message = "No download client selected"))
+            logger.error { "Resume failed: no download-client API for id $clientId" }
+            emit(OperationStatus.Error(message = "Download client not available"))
             return@flow
         }
 
         when (val result = api.resumeDownload(ids)) {
             is NetworkResult.Success -> emit(OperationStatus.Success("Downloads resumed"))
-            is NetworkResult.Error -> emit(OperationStatus.Error(result.code, result.message, result.cause))
+            is NetworkResult.Error -> {
+                logger.error(result.cause) {
+                    "Resume failed on client $clientId (ids=$ids): ${result.message} (code=${result.code})"
+                }
+                emit(OperationStatus.Error(result.code, result.message, result.cause))
+            }
             is NetworkResult.Loading -> emit(OperationStatus.InProgress)
         }
     }

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/viewmodel/DownloadQueueViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/viewmodel/DownloadQueueViewModel.kt
@@ -20,11 +20,15 @@ import com.dnfapps.arrmatey.downloadclient.usecase.UpdateDownloadClientPreferenc
 import com.dnfapps.arrmatey.extensions.orderedSortedWith
 import com.dnfapps.arrmatey.instances.usecase.ObserveDownloadClientPreferencesUseCase
 import com.dnfapps.arrmatey.utils.MultiSelectState
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.last
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -154,26 +158,36 @@ class DownloadQueueViewModel(
     }
 
     fun pauseDownload(id: String) {
-        viewModelScope.launch {
-            pauseDownloadUseCase(listOf(id)).collect { state ->
-                _commandState.value = state.toCommandState()
-                if (state is OperationStatus.Success) downloadQueueService.manualRefresh()
-            }
+        runSingleItemOp(id) { clientId ->
+            pauseDownloadUseCase(clientId, listOf(id))
         }
     }
 
     fun resumeDownload(id: String) {
-        viewModelScope.launch {
-            resumeDownloadUseCase(listOf(id)).collect { state ->
-                _commandState.value = state.toCommandState()
-                if (state is OperationStatus.Success) downloadQueueService.manualRefresh()
-            }
+        runSingleItemOp(id) { clientId ->
+            resumeDownloadUseCase(clientId, listOf(id))
         }
     }
 
     fun deleteDownload(id: String, deleteFiles: Boolean) {
+        runSingleItemOp(id) { clientId ->
+            deleteDownloadUseCase(clientId, listOf(id), deleteFiles)
+        }
+    }
+
+    private fun runSingleItemOp(
+        id: String,
+        op: (clientId: Long) -> Flow<OperationStatus>
+    ) {
         viewModelScope.launch {
-            deleteDownloadUseCase(listOf(id), deleteFiles).collect { state ->
+            val clientId = downloadQueueState.value.queueItems.firstOrNull { it.id == id }?.client?.id
+            if (clientId == null) {
+                _commandState.value = DownloadClientCommandState.Error(
+                    message = "Download item no longer available"
+                )
+                return@launch
+            }
+            op(clientId).collect { state ->
                 _commandState.value = state.toCommandState()
                 if (state is OperationStatus.Success) downloadQueueService.manualRefresh()
             }
@@ -212,34 +226,61 @@ class DownloadQueueViewModel(
     }
 
     fun pauseSelected() {
-        viewModelScope.launch {
-            val selected = selectionState.selectedItems.value.toList()
-            if (selected.isEmpty()) return@launch
-            pauseDownloadUseCase(selected).collect { state ->
-                if (state is OperationStatus.Success) downloadQueueService.manualRefresh()
-            }
-            exitSelectionMode()
-        }
+        runBulkOp { clientId, ids -> pauseDownloadUseCase(clientId, ids) }
     }
 
     fun resumeSelected() {
-        viewModelScope.launch {
-            val selected = selectionState.selectedItems.value.toList()
-            if (selected.isEmpty()) return@launch
-            resumeDownloadUseCase(selected).collect { state ->
-                if (state is OperationStatus.Success) downloadQueueService.manualRefresh()
-            }
-            exitSelectionMode()
-        }
+        runBulkOp { clientId, ids -> resumeDownloadUseCase(clientId, ids) }
     }
 
     fun deleteSelected(deleteFiles: Boolean) {
+        runBulkOp { clientId, ids -> deleteDownloadUseCase(clientId, ids, deleteFiles) }
+    }
+
+    private fun runBulkOp(
+        op: (clientId: Long, ids: List<String>) -> Flow<OperationStatus>
+    ) {
         viewModelScope.launch {
-            val selected = selectionState.selectedItems.value.toList()
-            if (selected.isEmpty()) return@launch
-            deleteDownloadUseCase(selected, deleteFiles).collect { state ->
-                if (state is OperationStatus.Success) downloadQueueService.manualRefresh()
+            val selectedIds = selectionState.selectedItems.value
+            if (selectedIds.isEmpty()) return@launch
+
+            val itemsById = downloadQueueState.value.queueItems.associateBy { it.id }
+            val idsByClient = selectedIds
+                .mapNotNull { id -> itemsById[id]?.let { it.client.id to id } }
+                .groupBy({ it.first }, { it.second })
+
+            if (idsByClient.isEmpty()) {
+                _commandState.value = DownloadClientCommandState.Error(
+                    message = "No items available for this action"
+                )
+                exitSelectionMode()
+                return@launch
             }
+
+            _commandState.value = DownloadClientCommandState.Loading
+
+            val results = idsByClient.entries
+                .map { (clientId, ids) -> async { op(clientId, ids).last() } }
+                .awaitAll()
+
+            val errors = results.filterIsInstance<OperationStatus.Error>()
+            val anySuccess = results.any { it is OperationStatus.Success }
+
+            _commandState.value = when {
+                errors.isEmpty() -> DownloadClientCommandState.Success
+                anySuccess -> DownloadClientCommandState.Error(
+                    message = "Partial failure on ${errors.size} of ${results.size} clients: " +
+                            errors.mapNotNull { it.message }.joinToString("; ")
+                )
+                else -> DownloadClientCommandState.Error(
+                    code = errors.first().code,
+                    message = errors.mapNotNull { it.message }.joinToString("; ")
+                        .ifBlank { "Operation failed" },
+                    cause = errors.first().cause
+                )
+            }
+
+            if (anySuccess) downloadQueueService.manualRefresh()
             exitSelectionMode()
         }
     }


### PR DESCRIPTION
Fix deleting on the Downloads tab when multiple Downloads clients are configured by passing the client id in to use.

Also add error logging and error display UI for Downloads tab:

* Android tested briefly
* iOS not tested

Fixes https://github.com/owenlejeune/ArrMatey/issues/151
