### PR TITLE
Fix qBittorrent api key

### DIFF
--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/ClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/ClientFactory.kt
@@ -2,10 +2,12 @@ package com.dnfapps.arrmatey.arr.api.client
 
 import com.dnfapps.arrmatey.datastore.PreferencesStore
 import com.dnfapps.arrmatey.downloadclient.model.DownloadClient
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClientType
 import com.dnfapps.arrmatey.instances.model.HeaderRestrictionType
 import com.dnfapps.arrmatey.instances.model.Instance
 import com.dnfapps.arrmatey.utils.getNetworkUtils
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.plugins.HttpTimeout
@@ -17,6 +19,7 @@ import io.ktor.client.plugins.logging.Logger
 import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.basicAuth
 import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -99,6 +102,7 @@ class HttpClientFactory(private val json: Json, private val logger: Logger) {
 
     fun createDownloadClient(downloadClient: DownloadClient): HttpClient =
         HttpClient {
+            expectSuccess = true
             install(ContentNegotiation) {
                 json(json)
             }
@@ -109,7 +113,11 @@ class HttpClientFactory(private val json: Json, private val logger: Logger) {
             }
 
             install(HttpRequestRetry) {
-                retryOnExceptionOrServerErrors(maxRetries = 3)
+                // Never retry 4xx: repeated failed auth triggers qBittorrent's IP ban.
+                retryOnServerErrors(maxRetries = 3)
+                retryOnExceptionIf(maxRetries = 3) { _, cause ->
+                    cause !is ClientRequestException
+                }
                 exponentialDelay()
             }
 
@@ -130,7 +138,13 @@ class HttpClientFactory(private val json: Json, private val logger: Logger) {
                     url.password = null
                 }
                 if (!downloadClient.noApiKeyRequired && downloadClient.apiKey.value.isNotEmpty()) {
-                    header(HEADER_X_API_KEY, downloadClient.apiKey.value)
+                    when (downloadClient.type) {
+                        // qBittorrent >= 5.2 only accepts API keys via Authorization: Bearer.
+                        DownloadClientType.QBittorrent ->
+                            header(HttpHeaders.Authorization, "Bearer ${downloadClient.apiKey.value}")
+                        else ->
+                            header(HEADER_X_API_KEY, downloadClient.apiKey.value)
+                    }
                 }
                 downloadClient.headers.forEach { header ->
                     val shouldSend = when (header.restrictionType) {

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/api/QBittorrentClient.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/api/QBittorrentClient.kt
@@ -11,6 +11,7 @@ import com.dnfapps.arrmatey.downloadclient.model.DownloadItemStatus
 import com.dnfapps.arrmatey.downloadclient.model.DownloadTransferInfo
 import io.ktor.client.HttpClient
 import io.ktor.client.request.forms.FormDataContent
+import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.Parameters
@@ -23,7 +24,17 @@ class QBittorrentClient(
     private var authenticated: Boolean = false
 
     override suspend fun testConnection(): NetworkResult<Unit> {
-        return ensureAuthenticated()
+        // Probe a real endpoint: /auth/login is unused with API keys and can pass even when data calls are rejected.
+        return when (val authResult = ensureAuthenticated()) {
+            is NetworkResult.Success -> {
+                httpClient.safeCall<Unit> {
+                    get("api/v2/app/version")
+                    Unit
+                }
+            }
+            is NetworkResult.Error -> authResult
+            is NetworkResult.Loading -> NetworkResult.Loading
+        }
     }
 
     override suspend fun getDownloads(): NetworkResult<List<DownloadItem>> {
@@ -94,6 +105,18 @@ class QBittorrentClient(
 
     private suspend fun ensureAuthenticated(): NetworkResult<Unit> {
         if (authenticated) return NetworkResult.Success(Unit)
+
+        // API-key auth is stateless via Authorization: Bearer; /auth/login rejects keys and repeated failures IP-ban.
+        if (downloadClient.apiKey.value.isNotEmpty()) {
+            authenticated = true
+            return NetworkResult.Success(Unit)
+        }
+
+        // Nothing to log in with; rely on WebUI subnet whitelist / disabled auth.
+        if (downloadClient.username.value.isEmpty() && downloadClient.password.value.isEmpty()) {
+            authenticated = true
+            return NetworkResult.Success(Unit)
+        }
 
         val loginResult = httpClient.safeCall {
             post("api/v2/auth/login") {


### PR DESCRIPTION
Fix qBittorrent api key usage and error handling:

* set `expectSuccess` so the client raises Exceptions on errors
* only retry on 5xx responses and exceptions
* send the API key using `Authorization: Bearer`

Fixes https://github.com/owenlejeune/ArrMatey/issues/155
