### PR TITLE
Fix qBittorrent auth latching on failed logins

### DIFF
--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/ClientFactory.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/ClientFactory.kt
@@ -99,6 +99,7 @@ class HttpClientFactory(private val json: Json, private val logger: Logger) {
 
     fun createDownloadClient(downloadClient: DownloadClient): HttpClient =
         HttpClient {
+            expectSuccess = true
             install(ContentNegotiation) {
                 json(json)
             }

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/api/QBittorrentClient.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/api/QBittorrentClient.kt
@@ -26,70 +26,66 @@ class QBittorrentClient(
         return ensureAuthenticated()
     }
 
-    override suspend fun getDownloads(): NetworkResult<List<DownloadItem>> {
-        return when (val authResult = ensureAuthenticated()) {
-            is NetworkResult.Success -> {
-                httpClient.safeGet<List<QBittorrentTorrent>>("api/v2/torrents/info")
-                    .map { torrents -> torrents.map { it.toDownloadItem() } }
-            }
-            is NetworkResult.Error -> authResult
-            is NetworkResult.Loading -> NetworkResult.Loading
+    override suspend fun getDownloads(): NetworkResult<List<DownloadItem>> =
+        authenticatedCall {
+            httpClient.safeGet<List<QBittorrentTorrent>>("api/v2/torrents/info")
+                .map { torrents -> torrents.map { it.toDownloadItem() } }
         }
-    }
 
-    override suspend fun pauseDownload(ids: List<String>): NetworkResult<Unit> {
-        return when (val authResult = ensureAuthenticated()) {
-            is NetworkResult.Success -> postTorrentAction("api/v2/torrents/stop", ids)
-            is NetworkResult.Error -> authResult
-            is NetworkResult.Loading -> NetworkResult.Loading
-        }
-    }
+    override suspend fun pauseDownload(ids: List<String>): NetworkResult<Unit> =
+        authenticatedCall { postTorrentAction("api/v2/torrents/stop", ids) }
 
-    override suspend fun resumeDownload(ids: List<String>): NetworkResult<Unit> {
-        return when (val authResult = ensureAuthenticated()) {
-            is NetworkResult.Success -> postTorrentAction("api/v2/torrents/start", ids)
-            is NetworkResult.Error -> authResult
-            is NetworkResult.Loading -> NetworkResult.Loading
-        }
-    }
+    override suspend fun resumeDownload(ids: List<String>): NetworkResult<Unit> =
+        authenticatedCall { postTorrentAction("api/v2/torrents/start", ids) }
 
-    override suspend fun deleteDownload(ids: List<String>, deleteFiles: Boolean): NetworkResult<Unit> {
-        return when (val authResult = ensureAuthenticated()) {
-            is NetworkResult.Success -> {
-                httpClient.safeCall {
-                    post("api/v2/torrents/delete") {
-                        setBody(
-                            FormDataContent(
-                                Parameters.build {
-                                    append("hashes", ids.joinToString("|"))
-                                    append("deleteFiles", deleteFiles.toString())
-                                }
-                            )
+    override suspend fun deleteDownload(ids: List<String>, deleteFiles: Boolean): NetworkResult<Unit> =
+        authenticatedCall {
+            httpClient.safeCall {
+                post("api/v2/torrents/delete") {
+                    setBody(
+                        FormDataContent(
+                            Parameters.build {
+                                append("hashes", ids.joinToString("|"))
+                                append("deleteFiles", deleteFiles.toString())
+                            }
                         )
-                    }
-                    Unit
+                    )
                 }
+                Unit
             }
-            is NetworkResult.Error -> authResult
-            is NetworkResult.Loading -> NetworkResult.Loading
         }
-    }
 
-    override suspend fun getTransferInfo(): NetworkResult<DownloadTransferInfo> {
-        return when (val authResult = ensureAuthenticated()) {
-            is NetworkResult.Success -> {
-                httpClient.safeGet<QBittorrentTransferInfoResponse>("api/v2/transfer/info")
-                    .map { info ->
-                        DownloadTransferInfo(
-                            client = downloadClient,
-                            downloadSpeed = info.downloadSpeed,
-                            uploadSpeed = info.uploadSpeed
-                        )
-                    }
-            }
-            is NetworkResult.Error -> authResult
-            is NetworkResult.Loading -> NetworkResult.Loading
+    override suspend fun getTransferInfo(): NetworkResult<DownloadTransferInfo> =
+        authenticatedCall {
+            httpClient.safeGet<QBittorrentTransferInfoResponse>("api/v2/transfer/info")
+                .map { info ->
+                    DownloadTransferInfo(
+                        client = downloadClient,
+                        downloadSpeed = info.downloadSpeed,
+                        uploadSpeed = info.uploadSpeed
+                    )
+                }
         }
+
+    // Re-login and retry once on 401/403 so an expired session cookie recovers automatically.
+    private suspend fun <T> authenticatedCall(
+        block: suspend () -> NetworkResult<T>
+    ): NetworkResult<T> {
+        when (val auth = ensureAuthenticated()) {
+            is NetworkResult.Error -> return auth
+            is NetworkResult.Loading -> return NetworkResult.Loading
+            is NetworkResult.Success -> Unit
+        }
+        val first = block()
+        if (first is NetworkResult.Error && (first.code == 401 || first.code == 403)) {
+            authenticated = false
+            when (val reAuth = ensureAuthenticated()) {
+                is NetworkResult.Error -> return reAuth
+                is NetworkResult.Loading -> return NetworkResult.Loading
+                is NetworkResult.Success -> return block()
+            }
+        }
+        return first
     }
 
     private suspend fun ensureAuthenticated(): NetworkResult<Unit> {

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/repository/DownloadClientManager.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/repository/DownloadClientManager.kt
@@ -27,6 +27,9 @@ class DownloadClientManager(
     private val _downloadClientApis = MutableStateFlow<Map<Long, DownloadClientApi>>(emptyMap())
     val downloadClientApis: StateFlow<Map<Long, DownloadClientApi>> = _downloadClientApis
 
+    // Tracks the DownloadClient row backing each cached API so edits trigger a rebuild.
+    private val cachedClients: MutableMap<Long, DownloadClient> = mutableMapOf()
+
     init {
         observeDownloadClients()
     }
@@ -41,22 +44,23 @@ class DownloadClientManager(
     }
 
     private fun updateClientApis(downloadClients: List<DownloadClient>) {
-        val currentClients = _downloadClientApis.value.toMutableMap()
-        val downloadClientIds = downloadClients.map { it.id }.toSet()
+        val currentApis = _downloadClientApis.value.toMutableMap()
+        val incomingIds = downloadClients.mapTo(mutableSetOf()) { it.id }
 
-        currentClients.keys
-            .filterNot { it in downloadClientIds }
-            .forEach { id ->
-                currentClients.remove(id)
-            }
+        (currentApis.keys - incomingIds).forEach { id ->
+            currentApis.remove(id)
+            cachedClients.remove(id)
+        }
 
         downloadClients.forEach { downloadClient ->
-            if (!currentClients.containsKey(downloadClient.id)) {
-                currentClients[downloadClient.id] = createApi(downloadClient)
+            val cached = cachedClients[downloadClient.id]
+            if (cached == null || cached != downloadClient) {
+                currentApis[downloadClient.id] = createApi(downloadClient)
+                cachedClients[downloadClient.id] = downloadClient
             }
         }
 
-        _downloadClientApis.value = currentClients
+        _downloadClientApis.value = currentApis
     }
 
     fun observeAllDownloadClients(): Flow<List<DownloadClient>> =
@@ -88,23 +92,27 @@ class DownloadClientManager(
         val api = createApi(client)
 
         _downloadClientApis.value += (id to api)
+        cachedClients[id] = client
 
         return api
     }
 
     suspend fun refreshApi(id: Long): DownloadClientApi? {
         _downloadClientApis.value -= id
+        cachedClients.remove(id)
 
         val client = downloadClientRepository.getDownloadClientById(id) ?: return null
         val api = createApi(client)
 
         _downloadClientApis.value += (id to api)
+        cachedClients[id] = client
 
         return api
     }
 
     fun removeApi(id: Long) {
         _downloadClientApis.value -= id
+        cachedClients.remove(id)
     }
 
     fun createApiFromClient(client: DownloadClient): DownloadClientApi {


### PR DESCRIPTION
Fix qBittorrent client latching on failed logins.

* create authenticatedCall to help check for 401, 403 responses and force re-authentcation
* set expectSuccess so that the client will throw exceptions on error responses
* allow changing passwords to actually take affect, by using a cachedClients MutableMap

Fixes https://github.com/owenlejeune/ArrMatey/issues/156
