### PR TITLE
Fix Prowlarr showing offline

### DIFF
--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/ProwlarrClient.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/api/client/ProwlarrClient.kt
@@ -1,5 +1,6 @@
 package com.dnfapps.arrmatey.arr.api.client
 
+import com.dnfapps.arrmatey.arr.api.model.ArrSoftwareStatus
 import com.dnfapps.arrmatey.arr.api.model.IndexerStatus
 import com.dnfapps.arrmatey.arr.api.model.ProwlarrGrabPayload
 import com.dnfapps.arrmatey.arr.api.model.ProwlarrIndexer
@@ -32,6 +33,9 @@ class ProwlarrClient(
         val url = "$baseUrl/${instance.type.testEndpoint}"
         return httpClient.safeGet(url)
     }
+
+    suspend fun getStatus(): NetworkResult<ArrSoftwareStatus> =
+        httpClient.safeGet("$baseUrl/system/status")
 
     suspend fun getIndexers(): NetworkResult<List<ProwlarrIndexer>> {
         val url = "$baseUrl/indexer"

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/state/CombinedDashboardState.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/state/CombinedDashboardState.kt
@@ -93,6 +93,7 @@ sealed interface CombinedDashboardState {
             val prowlarrStats = instances.filter { it.type == InstanceType.Prowlarr }.map {
                 ProwlarrDashboardState(
                     instance = it,
+                    softwareStatus = ArrSoftwareStatus(version = "1.0.0", appName = it.label),
                     totalIndexers = 10,
                     healthyIndexers = 8,
                     failingIndexers = 2
@@ -267,6 +268,7 @@ data class DownloadClientDashboardState(
 
 data class ProwlarrDashboardState(
     val instance: Instance,
+    val softwareStatus: ArrSoftwareStatus? = null,
     val totalIndexers: Int,
     val healthyIndexers: Int,
     val failingIndexers: Int

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/viewmodel/CombinedDashboardViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/viewmodel/CombinedDashboardViewModel.kt
@@ -143,11 +143,16 @@ class CombinedDashboardViewModel(
                         flowOf(emptyList())
                     } else {
                         val flows = prowlarrRepos.map { repo ->
-                            combine(repo.indexerStatus, repo.indexers) { status, indexers ->
+                            combine(
+                                repo.softwareStatus,
+                                repo.indexerStatus,
+                                repo.indexers
+                            ) { software, status, indexers ->
                                 val failureCount = status.count { it.hasFailure }
                                 ProwlarrDashboardState(
                                     instance = repo.instance,
-                                    totalIndexers = status.size,
+                                    softwareStatus = software,
+                                    totalIndexers = indexers.size,
                                     healthyIndexers = indexers.size - failureCount,
                                     failingIndexers = failureCount
                                 )
@@ -305,7 +310,7 @@ class CombinedDashboardViewModel(
                     isLocal = state.instance.isUsingLocalNetwork(),
                     currentEndpoint = state.instance.getEffectiveBaseUrl(),
                     icon = state.instance.type.icon,
-                    isOnline = state.totalIndexers > 0 || state.failingIndexers > 0,
+                    isOnline = state.softwareStatus != null,
                     isLocalSwitchingEnabled = state.instance.localNetworkEnabled
                 )
             )
@@ -374,6 +379,7 @@ class CombinedDashboardViewModel(
             val prowlarrRepos = instanceManager.instanceRepositories.value.values.filterIsInstance<ProwlarrInstanceRepository>()
             prowlarrRepos.forEach { repo ->
                 try {
+                    repo.refreshStatus()
                     repo.getIndexerStatus()
                     repo.getIndexers()
                 } catch (e: Exception) {

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/instances/repository/ProwlarrInstanceRepository.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/instances/repository/ProwlarrInstanceRepository.kt
@@ -2,6 +2,7 @@ package com.dnfapps.arrmatey.instances.repository
 
 import androidx.room.Index
 import com.dnfapps.arrmatey.arr.api.client.ProwlarrClient
+import com.dnfapps.arrmatey.arr.api.model.ArrSoftwareStatus
 import com.dnfapps.arrmatey.arr.api.model.IndexerStatus
 import com.dnfapps.arrmatey.arr.api.model.ProwlarrIndexer
 import com.dnfapps.arrmatey.arr.api.model.ProwlarrSearchResult
@@ -21,6 +22,9 @@ class ProwlarrInstanceRepository(
 
     private val prowlarrClient = ProwlarrClient(instance, httpClient)
 
+    private val _softwareStatus = MutableStateFlow<ArrSoftwareStatus?>(null)
+    val softwareStatus: StateFlow<ArrSoftwareStatus?> = _softwareStatus.asStateFlow()
+
     private val _indexerStatus = MutableStateFlow<List<IndexerStatus>>(emptyList())
     val indexerStatus: StateFlow<List<IndexerStatus>> = _indexerStatus.asStateFlow()
 
@@ -29,6 +33,11 @@ class ProwlarrInstanceRepository(
 
     override suspend fun testConnection(): NetworkResult<Unit> =
         prowlarrClient.testConnection()
+
+    suspend fun refreshStatus() {
+        prowlarrClient.getStatus()
+            .onSuccess { _softwareStatus.value = it }
+    }
 
     suspend fun getIndexers(): NetworkResult<List<ProwlarrIndexer>> =
         prowlarrClient.getIndexers().onSuccess { _indexers.value = it }


### PR DESCRIPTION
Fix Prowlarr showing offline when it shouldnt:

* Add `getStatus()` and use `ArrSoftwareStatus` in `ProwlarrClient`
* Expose the status in the `ProwlarrInstanceRepository`
* Add to the `CombinedDashboardState`
* fix the `CombinedDashboardViewModel` to use that status for the status displayed

Fixes https://github.com/owenlejeune/ArrMatey/issues/157


