### PR TITLE
Fix adding movies or series failing silently without seerr

### DIFF
--- a/shared/src/androidUnitTest/kotlin/com/dnfapps/arrmatey/viewmodel/UnifiedMediaDetailsViewModelTest.kt
+++ b/shared/src/androidUnitTest/kotlin/com/dnfapps/arrmatey/viewmodel/UnifiedMediaDetailsViewModelTest.kt
@@ -62,6 +62,7 @@ class UnifiedMediaDetailsViewModelTest {
                 removeSeerrMediaFileUseCase = mockk(),
                 clearSeerrMediaDataUseCase = mockk(),
                 markSeerrMediaAsAvailableUseCase = mockk(),
+                logger = mockk(relaxed = true),
             )
 
         assertEquals(InstanceType.Radarr, viewModel.resolvedInstanceType)

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/usecase/AddMediaItemUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/usecase/AddMediaItemUseCase.kt
@@ -4,11 +4,14 @@ import com.dnfapps.arrmatey.arr.api.model.ArrMedia
 import com.dnfapps.arrmatey.arr.api.model.AudiobookMetadataResponse
 import com.dnfapps.arrmatey.arr.api.model.SearchAudiobook
 import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
 import com.dnfapps.arrmatey.instances.repository.InstanceManager
+import dev.shivathapaa.logger.api.Logger
 import kotlinx.coroutines.flow.firstOrNull
 
 class AddMediaItemUseCase(
     private val instanceManager: InstanceManager,
+    private val logger: Logger,
 ) {
     suspend operator fun invoke(
         instanceType: InstanceType,
@@ -25,9 +28,23 @@ class AddMediaItemUseCase(
             }
 
         if (repository == null) {
+            logger.error {
+                "AddMediaItemUseCase: no repository resolved (type=$instanceType, targetInstanceId=$targetInstanceId); " +
+                    "add aborted for item '${item.title}'"
+            }
             return
         }
 
+        invoke(instanceType, repository, item, metadata, searchOnAdd)
+    }
+
+    suspend operator fun invoke(
+        instanceType: InstanceType,
+        repository: ArrInstanceRepository,
+        item: ArrMedia,
+        metadata: AudiobookMetadataResponse? = null,
+        searchOnAdd: Boolean = false,
+    ) {
         if (
             instanceType == InstanceType.Listenarr &&
             metadata != null &&

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/usecase/SmartAddMediaUseCase.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/usecase/SmartAddMediaUseCase.kt
@@ -3,6 +3,7 @@ package com.dnfapps.arrmatey.arr.usecase
 import com.dnfapps.arrmatey.arr.api.model.ArrMedia
 import com.dnfapps.arrmatey.arr.api.model.AudiobookMetadataResponse
 import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
 import com.dnfapps.arrmatey.instances.repository.SeerrInstanceRepository
 import com.dnfapps.arrmatey.seerr.api.model.ApprovalStatus
 import com.dnfapps.arrmatey.seerr.api.model.RequestMediaDetails
@@ -28,7 +29,32 @@ class SmartAddMediaUseCase(
             searchOnAdd = searchOnAdd,
             targetInstanceId = targetInstanceId,
         )
+        approvePendingSeerrRequest(seerrMediaDetails, seerrRepository)
+    }
 
+    suspend operator fun invoke(
+        instanceType: InstanceType,
+        repository: ArrInstanceRepository,
+        item: ArrMedia,
+        metadata: AudiobookMetadataResponse? = null,
+        searchOnAdd: Boolean = false,
+        seerrMediaDetails: RequestMediaDetails? = null,
+        seerrRepository: SeerrInstanceRepository? = null,
+    ) {
+        addMediaItemUseCase(
+            instanceType = instanceType,
+            repository = repository,
+            item = item,
+            metadata = metadata,
+            searchOnAdd = searchOnAdd,
+        )
+        approvePendingSeerrRequest(seerrMediaDetails, seerrRepository)
+    }
+
+    private suspend fun approvePendingSeerrRequest(
+        seerrMediaDetails: RequestMediaDetails?,
+        seerrRepository: SeerrInstanceRepository?,
+    ) {
         if (seerrMediaDetails != null && seerrRepository != null) {
             val pendingRequest = seerrMediaDetails.mediaInfo?.requests?.firstOrNull { it.status == 1 }
             if (pendingRequest != null) {

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/viewmodel/MediaPreviewViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/arr/viewmodel/MediaPreviewViewModel.kt
@@ -19,7 +19,10 @@ import com.dnfapps.arrmatey.instances.usecase.GetArrInstanceRepositoryUseCase
 import com.dnfapps.arrmatey.instances.usecase.ObserveInstancePreferencesUseCase
 import com.dnfapps.arrmatey.instances.usecase.ObserveScopedReposByTypeUseCase
 import com.dnfapps.arrmatey.instances.usecase.UpdateInstancePreferencesUseCase
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -34,6 +37,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.milliseconds
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MediaPreviewViewModel(
@@ -46,7 +50,9 @@ class MediaPreviewViewModel(
     observeInstancePreferencesUseCase: ObserveInstancePreferencesUseCase,
     private val updateInstancePreferencesUseCase: UpdateInstancePreferencesUseCase,
     private val observeScopedReposByTypeUseCase: ObserveScopedReposByTypeUseCase,
+    private val logger: Logger,
 ) : ViewModel() {
+    private val _fallbackAddItemStatus = MutableStateFlow<OperationStatus>(OperationStatus.Idle)
     private val _selectedInstanceId = MutableStateFlow<Long?>(null)
     val selectedInstanceId: StateFlow<Long?> = _selectedInstanceId.asStateFlow()
 
@@ -189,6 +195,17 @@ class MediaPreviewViewModel(
                     repository.refreshAllMetadata()
                 }
 
+                val mergedAddItemStatus =
+                    combine(
+                        repository.addItemStatus,
+                        _fallbackAddItemStatus,
+                    ) { repoStatus, fallbackStatus ->
+                        if (repoStatus is OperationStatus.Idle && fallbackStatus !is OperationStatus.Idle) {
+                            fallbackStatus
+                        } else {
+                            repoStatus
+                        }
+                    }
                 combine(
                     combine(
                         repository.qualityProfiles,
@@ -198,7 +215,7 @@ class MediaPreviewViewModel(
                         Triple(qualityProfiles, rootFolders, tags)
                     },
                     combine(
-                        repository.addItemStatus,
+                        mergedAddItemStatus,
                         repository.lastAddedItemId,
                         previewPath,
                     ) { addItemStatus, lastAddedItemId, previewPath ->
@@ -235,9 +252,27 @@ class MediaPreviewViewModel(
         searchOnAdd: Boolean,
     ) {
         viewModelScope.launch {
+            val repository = selectedRepository.value
+            if (repository == null) {
+                logger.error {
+                    "MediaPreviewViewModel.addItem: selectedRepository is null (type=$instanceType); cannot add '${item.title}'"
+                }
+                _fallbackAddItemStatus.value = OperationStatus.Error(message = "No instance available")
+                delay(1500.milliseconds)
+                _fallbackAddItemStatus.value = OperationStatus.Idle
+                return@launch
+            }
             val metadata = metadataResponse.value
-            val targetId = selectedRepository.value?.instance?.id
-            addMediaUseCase(instanceType, item, metadata, searchOnAdd, targetInstanceId = targetId)
+            logger.info {
+                "MediaPreviewViewModel.addItem: adding '${item.title}' to instance ${repository.instance.id} (${repository.instance.label})"
+            }
+            addMediaUseCase(
+                instanceType = instanceType,
+                repository = repository,
+                item = item,
+                metadata = metadata,
+                searchOnAdd = searchOnAdd,
+            )
         }
     }
 

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/di/Modules.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/di/Modules.kt
@@ -277,7 +277,7 @@ val useCaseModule =
         factory { GetMediaDetailsUseCase(get()) }
         factory { UpdateInstancePreferencesUseCase(get()) }
         factory { ObserveInstancePreferencesUseCase(get(), get()) }
-        factory { AddMediaItemUseCase(get()) }
+        factory { AddMediaItemUseCase(get(), get()) }
         factory { GetActivityTasksUseCase(get()) }
         factory { ObserveAllInstancesByTypeUseCase(get()) }
         factory { ObserveAllInstancesUseCase(get()) }
@@ -287,7 +287,7 @@ val useCaseModule =
         factory { SetInstanceActiveUseCase(get()) }
         factory { GetLookupResultsUseCase(get()) }
         factory { PerformLookupUseCase(get()) }
-        factory { AddMediaItemUseCase(get()) }
+        factory { AddMediaItemUseCase(get(), get()) }
         factory { GetReleasesUseCase(get()) }
         factory { DownloadReleaseUseCase(get()) }
         factory { GetMovieFilesUseCase(get()) }
@@ -446,6 +446,7 @@ val viewModelModule =
                 removeSeerrMediaFileUseCase = get(),
                 clearSeerrMediaDataUseCase = get(),
                 markSeerrMediaAsAvailableUseCase = get(),
+                logger = get(),
             )
         }
         factory { (type: InstanceType) ->
@@ -455,7 +456,7 @@ val viewModelModule =
             ArrSearchViewModel(type, instanceId, get(), get(), get(), get(), get())
         }
         factory { (preview: ArrMedia, type: InstanceType) ->
-            MediaPreviewViewModel(preview, type, get(), get(), get(), get(), get(), get(), get())
+            MediaPreviewViewModel(preview, type, get(), get(), get(), get(), get(), get(), get(), get())
         }
         factory { (type: InstanceType, defaultFilter: ReleaseFilterBy) ->
             InteractiveSearchViewModel(type, defaultFilter, get(), get(), get(), get())

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/viewmodel/UnifiedMediaDetailsViewModel.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/viewmodel/UnifiedMediaDetailsViewModel.kt
@@ -65,6 +65,7 @@ import com.dnfapps.arrmatey.seerr.usecase.SubmitIssueUseCase
 import com.dnfapps.arrmatey.seerr.usecase.SubmitRequestUseCase
 import com.dnfapps.networking.onError
 import com.dnfapps.networking.onSuccess
+import dev.shivathapaa.logger.api.Logger
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
@@ -119,6 +120,7 @@ class UnifiedMediaDetailsViewModel(
     private val removeSeerrMediaFileUseCase: RemoveSeerrMediaFileUseCase,
     private val clearSeerrMediaDataUseCase: ClearSeerrMediaDataUseCase,
     private val markSeerrMediaAsAvailableUseCase: MarkSeerrMediaAsAvailableUseCase,
+    private val logger: Logger,
 ) : ViewModel() {
     private var seerrMediaId: Long? = null
     private var initialInstanceId: Long? = null
@@ -702,10 +704,10 @@ class UnifiedMediaDetailsViewModel(
         if (selectedId != null) {
             getArrInstanceRepositoryUseCase(selectedId)?.let { return it }
         }
-        return activeArrRepoFlow.filterNotNull().firstOrNull()
+        return activeArrRepoFlow.firstOrNull()
     }
 
-    private suspend fun getSeerrRepository(): SeerrInstanceRepository? = seerrRepositoryFlow.filterNotNull().firstOrNull()
+    private suspend fun getSeerrRepository(): SeerrInstanceRepository? = seerrRepositoryFlow.firstOrNull()
 
     private fun getEffectiveArrMedia(): ArrMedia? {
         val selectedId = _selectedInstanceId.value
@@ -808,6 +810,15 @@ class UnifiedMediaDetailsViewModel(
         targetInstanceId: Long? = null,
     ) {
         viewModelScope.launch {
+            val type = resolvedInstanceType
+            if (type == null) {
+                logger.error {
+                    "UnifiedMediaDetailsViewModel.smartAdd: resolvedInstanceType is null (requestType=$requestType, instanceType=$instanceType); cannot add '${item.title}'"
+                }
+                emitFallbackAddError("Unsupported media type")
+                return@launch
+            }
+
             val seerrRepo = getSeerrRepository()
             val successState = uiState.value as? UnifiedMediaDetailsUiState.Success
             val effectiveInstanceId =
@@ -820,26 +831,40 @@ class UnifiedMediaDetailsViewModel(
                     getActiveArrRepository()
                 }
 
+            if (targetRepo == null) {
+                logger.error {
+                    "UnifiedMediaDetailsViewModel.smartAdd: no repository resolved (type=$type, effectiveInstanceId=$effectiveInstanceId); cannot add '${item.title}'"
+                }
+                emitFallbackAddError("No instance available")
+                return@launch
+            }
+
             val collectJob =
-                if (targetRepo != null) {
-                    launch {
-                        targetRepo.addItemStatus.collect { _addItemStatus.value = it }
-                    }
-                } else {
-                    null
+                launch {
+                    targetRepo.addItemStatus.collect { _addItemStatus.value = it }
                 }
 
+            logger.info {
+                "UnifiedMediaDetailsViewModel.smartAdd: adding '${item.title}' to instance ${targetRepo.instance.id} (${targetRepo.instance.label}) type=$type searchOnAdd=$searchOnAdd"
+            }
+
             smartAddMediaUseCase(
-                instanceType = resolvedInstanceType ?: return@launch,
+                instanceType = type,
+                repository = targetRepo,
                 item = item,
                 searchOnAdd = searchOnAdd,
                 seerrMediaDetails = successState?.seerrMedia,
                 seerrRepository = seerrRepo,
-                targetInstanceId = effectiveInstanceId,
             )
             refresh()
-            collectJob?.cancel()
+            collectJob.cancel()
         }
+    }
+
+    private suspend fun emitFallbackAddError(message: String) {
+        _addItemStatus.value = OperationStatus.Error(message = message)
+        delay(1500)
+        _addItemStatus.value = OperationStatus.Idle
     }
 
     fun submitRequest(


### PR DESCRIPTION
Fix adding movies or series failing silently without seerr.

`UnifiedMediaDetailsViewModel.getSeerrRepository()` called `seerrRepositoryFlow.filterNotNull().firstOrNull()`.  when there is no seerr, `seerrRepositoryFlow` emits null, which is filtered out by `filterNotNull` leaving `firstOrNull` waiting indefinitely, causing the `smartAdd` to hang before any logging happened.  This made it look like tapping save did nothing with no action, no logs, etc.

The same thing is in `getActiveArrRepository` so fix that too.

Also added some logging to log something when a similar problem happens in the future.

Tested on Android without a seerr instance.

Fixes https://github.com/owenlejeune/ArrMatey/issues/190
