### PR TITLE
Add renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,108 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    ":semanticCommits",
+    ":dependencyDashboard"
+  ],
+  "schedule": ["before 6am on monday"],
+  "timezone": "America/New_York",
+  "prConcurrentLimit": 5,
+  "prHourlyLimit": 2,
+  "labels": ["dependencies"],
+  "rangeStrategy": "bump",
+  "minimumReleaseAge": "3 days",
+  "packageRules": [
+    {
+      "description": "Kotlin + Compose group (lockstep)",
+      "matchPackagePatterns": [
+        "^org\\.jetbrains\\.kotlin",
+        "^org\\.jetbrains\\.compose",
+        "^androidx\\.compose",
+        "^com\\.google\\.devtools\\.ksp"
+      ],
+      "groupName": "kotlin + compose",
+      "schedule": ["before 6am on the first day of the month"]
+    },
+    {
+      "description": "AGP + Gradle wrapper (lockstep)",
+      "matchPackagePatterns": ["^com\\.android"],
+      "matchManagers": ["gradle", "gradle-wrapper"],
+      "groupName": "AGP + Gradle"
+    },
+    {
+      "description": "Ktor group",
+      "matchPackagePatterns": ["^io\\.ktor"],
+      "groupName": "ktor"
+    },
+    {
+      "description": "Coil group",
+      "matchPackagePatterns": ["^io\\.coil-kt"],
+      "groupName": "coil"
+    },
+    {
+      "description": "Koin group",
+      "matchPackagePatterns": ["^io\\.insert-koin"],
+      "groupName": "koin"
+    },
+    {
+      "description": "Skie → Kotlin group",
+      "matchPackagePatterns": ["^co\\.touchlab\\.skie"],
+      "groupName": "kotlin + compose"
+    },
+    {
+      "description": "moko-resources → Kotlin group",
+      "matchPackagePatterns": ["^dev\\.icerock"],
+      "groupName": "kotlin + compose"
+    },
+    {
+      "description": "Test/build tooling: automerge patch+minor",
+      "matchPackagePatterns": [
+        "^io\\.mockk",
+        "^app\\.cash\\.turbine",
+        "^org\\.robolectric",
+        "^com\\.diffplug\\.spotless",
+        "^androidx\\.test"
+      ],
+      "matchUpdateTypes": ["patch", "minor"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Runtime libs: automerge patch only (add per-family minor rules as integration tests land)",
+      "matchDepTypes": ["dependencies", "implementation", "api"],
+      "matchUpdateTypes": ["patch"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true,
+      "platformAutomerge": true
+    },
+    {
+      "description": "Majors: manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "addLabels": ["major-update"]
+    },
+    {
+      "description": "0.x libs: manual review",
+      "matchCurrentVersion": "/^0/",
+      "automerge": false
+    },
+    {
+      "description": "GitHub Actions: automerge patch/minor/digest",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["patch", "minor", "digest"],
+      "automerge": true,
+      "platformAutomerge": true
+    }
+  ],
+  "vulnerabilityAlerts": {
+    "labels": ["security"],
+    "schedule": ["at any time"],
+    "automerge": false
+  },
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on the first day of the month"]
+  }
+}


### PR DESCRIPTION
Add a renovate.json file, which does these:

* Runs weekly, Monday before 6am Eastern so it's predictable
* Kotlin/Compose group runs monthly since those bumps are the highest-risk and rarely urgent.
* Vulnerability alerts bypass the schedule and open immediately (but never auto-merge).
* lockFileMaintenance runs monthly to refresh transitive resolutions.
* sets prConcurrentLimit: 5 and prHourlyLimit: 2 to prevent a wall of open PRs on first run and during busy weeks.
* sets minimumReleaseAge: "3 days" to ignore releases newer than 72 hours to let release settle
* sets rangeStrategy: "bump" to rewrite versions in libs.versions.toml in place instead of widening ranges.

Automerge behavior, based on current levels of testing:

* automerge test and build tooling patch and minor version bumps on "stable" releases (1.0+) after CI passes
* runtime libs automerge patch only
* do not automerge runtime llibs minor version
* Never automerge major version bumps
* Never automerge 0.x releases
* Automerge github actions
* Kotlin/compose: no automerge

Before merging this, if it looks good, do these steps to activate renovate:

* Install the Renovate GitHub App on the repo: https://github.com/apps/renovate
* Enable Settings → General → Pull Requests → Allow auto-merge  (to allow automerging as described)
* Add a branch protection rule on main requiring the Lint and Test and Build Android DEBUG App checks to ensure these bumps are required to pass CI before merging

Fixes https://github.com/owenlejeune/ArrMatey/issues/195
