### PR TITLE
Remove `getDrawableId` and enable resource shrinking 

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -125,7 +125,7 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
-            isShrinkResources = false
+            isShrinkResources = true
             proguardFiles(getDefaultProguardFile("proguard-android-optimize.txt"), "proguard-rules.pro")
         }
     }

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/entensions/ContextExtensions.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/entensions/ContextExtensions.kt
@@ -5,17 +5,7 @@ import android.content.Intent
 import android.net.Uri
 import android.provider.Settings
 import androidx.browser.customtabs.CustomTabsIntent
-import androidx.compose.runtime.Composable
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.net.toUri
-
-fun Context.getDrawableId(key: String): Int = resources.getIdentifier(key, "drawable", packageName)
-
-@Composable
-fun getDrawableId(key: String): Int {
-    val context = LocalContext.current
-    return context.getDrawableId(key)
-}
 
 fun Context.openLink(url: String) {
     val uri = url.toUri()


### PR DESCRIPTION
Remove the unused `getDrawableId` and enable resource shrinking. 

Fixes https://github.com/owenlejeune/ArrMatey/issues/199
