### PR TITLE
Convert count strings to plurals for translation support

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/bazarr/BazarrSubtitlesSection.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/bazarr/BazarrSubtitlesSection.kt
@@ -45,6 +45,7 @@ import com.dnfapps.arrmatey.instances.model.InstanceType
 import com.dnfapps.arrmatey.model.OperationStatus
 import com.dnfapps.arrmatey.shared.MR
 import com.dnfapps.arrmatey.ui.components.ContainerCard
+import com.dnfapps.arrmatey.utils.mokoPlural
 import com.dnfapps.arrmatey.utils.mokoString
 import dev.icerock.moko.resources.compose.painterResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -203,7 +204,7 @@ private fun EmbeddedSubtitlesCard(embedded: List<BazarrSubtitle>) {
         verticalArrangement = Arrangement.spacedBy(8.dp),
     ) {
         Text(
-            text = mokoString(MR.strings.bazarr_embedded_count, embedded.count()),
+            text = mokoPlural(MR.plurals.bazarr_embedded_count, embedded.count()),
             fontWeight = FontWeight.SemiBold,
         )
         FlowRow(

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrLibraryScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrLibraryScreen.kt
@@ -119,6 +119,7 @@ import com.dnfapps.arrmatey.ui.sheets.EditAudiobookSheet
 import com.dnfapps.arrmatey.ui.sheets.EditAuthorSheet
 import com.dnfapps.arrmatey.ui.sheets.EditMovieSheet
 import com.dnfapps.arrmatey.ui.sheets.EditSeriesSheet
+import com.dnfapps.arrmatey.utils.mokoPlural
 import com.dnfapps.arrmatey.utils.mokoString
 import com.skydoves.flexible.bottomsheet.material3.FlexibleBottomSheet
 import com.skydoves.flexible.core.FlexibleSheetSize
@@ -538,7 +539,7 @@ internal fun SelectionTopBar(
     TopAppBar(
         title = {
             Text(
-                text = mokoString(MR.strings.selected_count, count),
+                text = mokoPlural(MR.plurals.selected_count, count),
             )
         },
         navigationIcon = {

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/BazarrDetailsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/BazarrDetailsScreen.kt
@@ -86,6 +86,7 @@ import com.dnfapps.arrmatey.ui.components.bazarr.BazarrSubtitleSearchSheet
 import com.dnfapps.arrmatey.ui.helpers.LocalIsInTwoPane
 import com.dnfapps.arrmatey.ui.helpers.rememberRemoteImageData
 import com.dnfapps.arrmatey.utils.AspectRatio
+import com.dnfapps.arrmatey.utils.mokoPlural
 import com.dnfapps.arrmatey.utils.mokoString
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.parameter.parametersOf
@@ -254,10 +255,10 @@ fun BazarrDetailsScreen(
                         is BazarrSeries ->
                             buildMap {
                                 put(mokoString(MR.strings.path), details.path)
-                                put(mokoString(MR.strings.files), mokoString(MR.strings.bazarr_files_count, details.episodeFileCount))
+                                put(mokoString(MR.strings.files), mokoPlural(MR.plurals.bazarr_files_count, details.episodeFileCount))
                                 put(
                                     mokoString(MR.strings.missing),
-                                    mokoString(MR.strings.bazarr_missing_count, details.episodeMissingCount),
+                                    mokoPlural(MR.plurals.bazarr_missing_count, details.episodeMissingCount),
                                 )
                                 put(
                                     mokoString(MR.strings.status),

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/BazarrScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/BazarrScreen.kt
@@ -82,6 +82,7 @@ import com.dnfapps.arrmatey.ui.components.navigation.NavigationDrawerButton
 import com.dnfapps.arrmatey.ui.helpers.rememberRemoteImageData
 import com.dnfapps.arrmatey.ui.theme.TranslucentBlack
 import com.dnfapps.arrmatey.utils.AspectRatio
+import com.dnfapps.arrmatey.utils.mokoPlural
 import com.dnfapps.arrmatey.utils.mokoString
 import dev.icerock.moko.resources.compose.painterResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -437,12 +438,14 @@ private fun BazarrSeriesList(
                 monitored = item.monitored,
                 onClick = { onClick(item) },
             ) {
+                val totalEpisodes = item.episodeFileCount + item.episodeMissingCount
                 Text(
                     text =
-                        mokoString(
-                            MR.strings.bazarr_series_subtitle_count,
+                        mokoPlural(
+                            MR.plurals.bazarr_series_subtitle_count,
+                            totalEpisodes,
                             item.episodeFileCount,
-                            item.episodeFileCount + item.episodeMissingCount,
+                            totalEpisodes,
                         ),
                     color = Color.White,
                     fontSize = 14.sp,
@@ -474,8 +477,10 @@ private fun BazarrMoviesList(
             ) {
                 val subtitleCount = item.subtitles.size
                 val missingCount = item.missingSubtitles.size
+                val subtitlesText = mokoPlural(MR.plurals.bazarr_movie_subtitles_count, subtitleCount)
+                val missingText = mokoPlural(MR.plurals.bazarr_movie_missing_count, missingCount)
                 Text(
-                    text = mokoString(MR.strings.bazarr_movie_subtitle_count, subtitleCount, missingCount),
+                    text = mokoString(MR.strings.bazarr_movie_subtitle_summary, subtitlesText, missingText),
                     color = Color.White,
                     fontSize = 14.sp,
                 )

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/tabs/DownloadsTab.kt
@@ -106,6 +106,7 @@ import com.dnfapps.arrmatey.ui.theme.ArrGreen
 import com.dnfapps.arrmatey.ui.theme.ArrGrey
 import com.dnfapps.arrmatey.ui.theme.ArrPurple
 import com.dnfapps.arrmatey.ui.theme.ArrRed
+import com.dnfapps.arrmatey.utils.mokoPlural
 import com.dnfapps.arrmatey.utils.mokoString
 import com.skydoves.flexible.bottomsheet.material3.FlexibleBottomSheet
 import com.skydoves.flexible.core.FlexibleSheetSize
@@ -197,7 +198,7 @@ fun DownloadsTab(
                 )
             } else {
                 val count = queueState.queueItems.size
-                val placeholderLabel = mokoString(MR.strings.search_downloads, count)
+                val placeholderLabel = mokoPlural(MR.plurals.search_downloads, count)
 
                 ArrAppBarWithSearch(
                     textFieldState = textFieldState,
@@ -418,7 +419,7 @@ private fun SelectionTopBar(
     TopAppBar(
         title = {
             Text(
-                text = mokoString(MR.strings.selected_count, count),
+                text = mokoPlural(MR.plurals.selected_count, count),
             )
         },
         navigationIcon = {

--- a/iosApp/iosApp/Views/Components/ArrLibraryView.swift
+++ b/iosApp/iosApp/Views/Components/ArrLibraryView.swift
@@ -120,7 +120,7 @@ struct ArrLibraryView: View {
             }
             
             ToolbarItem(placement: .principal) {
-                Text(MR.strings().selected_count.format(args: [viewModel.selectionCount]).localized())
+                Text(MR.plurals().selected_count.localized(viewModel.selectionCount))
                     .font(.headline)
             }
             

--- a/iosApp/iosApp/Views/Components/BazarrInfoArea.swift
+++ b/iosApp/iosApp/Views/Components/BazarrInfoArea.swift
@@ -18,8 +18,8 @@ struct BazarrInfoArea: View {
         } else if let series = details as? BazarrSeries {
             var items = [
                 InfoItem(label: MR.strings().path.localized(), value: series.path),
-                InfoItem(label: MR.strings().files.localized(), value: MR.strings().bazarr_files_count.formatted(args: [series.episodeFileCount])),
-                InfoItem(label: MR.strings().missing.localized(), value: MR.strings().bazarr_missing_count.formatted(args: [series.episodeMissingCount])),
+                InfoItem(label: MR.strings().files.localized(), value: MR.plurals().bazarr_files_count.localized(Int(series.episodeFileCount))),
+                InfoItem(label: MR.strings().missing.localized(), value: MR.plurals().bazarr_missing_count.localized(Int(series.episodeMissingCount))),
                 InfoItem(label: MR.strings().status.localized(), value: (series.ended ? MR.strings().ended : MR.strings().continuing).localized())
             ]
             

--- a/iosApp/iosApp/Views/Components/BazarrSubtitlesSection.swift
+++ b/iosApp/iosApp/Views/Components/BazarrSubtitlesSection.swift
@@ -129,7 +129,7 @@ private struct EmbeddedSubtitlesCard: View {
     
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(MR.strings().bazarr_embedded_count.formatted(args: [embedded.count]))
+            Text(MR.plurals().bazarr_embedded_count.localized(embedded.count))
                 .font(.subheadline)
                 .fontWeight(.semibold)
             

--- a/iosApp/iosApp/Views/Tabs/BazarrTab.swift
+++ b/iosApp/iosApp/Views/Tabs/BazarrTab.swift
@@ -165,6 +165,7 @@ private struct BazarrSeriesList: View {
     var body: some View {
         List {
             ForEach(series, id: \.serviceId) { item in
+                let totalEpisodes = item.episodeFileCount + item.episodeMissingCount
                 BazarrItemRow(
                     title: item.title,
                     year: item.year,
@@ -172,7 +173,7 @@ private struct BazarrSeriesList: View {
                     poster: item.poster,
                     fanart: item.fanart,
                     monitored: item.monitored,
-                    details: MR.strings().bazarr_series_subtitle_count.formatted(args: [item.episodeFileCount, item.episodeFileCount + item.episodeMissingCount])
+                    details: MR.plurals().bazarr_series_subtitle_count.formatted(Int(totalEpisodes), [item.episodeFileCount, totalEpisodes])
                 )
                 .onTapGesture { onClick(item) }
             }
@@ -187,6 +188,8 @@ private struct BazarrMoviesList: View {
     var body: some View {
         List {
             ForEach(movies, id: \.serviceId) { item in
+                let subtitlesText = MR.plurals().bazarr_movie_subtitles_count.localized(item.subtitles.count)
+                let missingText = MR.plurals().bazarr_movie_missing_count.localized(item.missingSubtitles.count)
                 BazarrItemRow(
                     title: item.title,
                     year: item.year,
@@ -194,7 +197,7 @@ private struct BazarrMoviesList: View {
                     poster: item.poster,
                     fanart: item.fanart,
                     monitored: item.monitored,
-                    details: MR.strings().bazarr_movie_subtitle_count.formatted(args: [item.subtitles.count, item.missingSubtitles.count])
+                    details: MR.strings().bazarr_movie_subtitle_summary.formatted(args: [subtitlesText, missingText])
                 )
                 .onTapGesture { onClick(item) }
             }

--- a/iosApp/iosApp/Views/Tabs/DownloadsTab.swift
+++ b/iosApp/iosApp/Views/Tabs/DownloadsTab.swift
@@ -20,7 +20,7 @@ struct DownloadsTab: View {
     
     private var searchPrompt: String {
         let count = viewModel.downloadQueueState.queueItems.count
-        return MR.strings().search_downloads.format(args: [count]).localized()
+        return MR.plurals().search_downloads.localized(count)
     }
 
     var body: some View {
@@ -99,7 +99,7 @@ struct DownloadsTab: View {
             }
         } message: {
             if viewModel.isInSelectionMode {
-                Text(MR.strings().selected_count.format(args: [viewModel.selectionCount]).localized())
+                Text(MR.plurals().selected_count.localized(viewModel.selectionCount))
             } else {
                 Text(deleteTarget?.name ?? "")
             }
@@ -116,7 +116,7 @@ struct DownloadsTab: View {
             }
             
             ToolbarItem(placement: .principal) {
-                Text(MR.strings().selected_count.format(args: [viewModel.selectionCount]).localized())
+                Text(MR.plurals().selected_count.localized(viewModel.selectionCount))
                     .font(.headline)
             }
             

--- a/iosApp/iosApp/Views/Tabs/LibraryTab.swift
+++ b/iosApp/iosApp/Views/Tabs/LibraryTab.swift
@@ -546,7 +546,7 @@ struct LibraryTabContent: View {
             }
             
             ToolbarItem(placement: .principal) {
-                Text(MR.strings().selected_count.format(args: [libraryViewModel.selectionCount]).localized())
+                Text(MR.plurals().selected_count.localized(libraryViewModel.selectionCount))
                     .font(.headline)
             }
             

--- a/shared/src/commonMain/moko-resources/base/plurals.xml
+++ b/shared/src/commonMain/moko-resources/base/plurals.xml
@@ -23,4 +23,36 @@
         <item quantity="one">%d book</item>
         <item quantity="other">%d books</item>
     </plurals>
+    <plurals name="selected_count">
+        <item quantity="one">%d selected</item>
+        <item quantity="other">%d selected</item>
+    </plurals>
+    <plurals name="search_downloads">
+        <item quantity="one">Search %d download</item>
+        <item quantity="other">Search %d downloads</item>
+    </plurals>
+    <plurals name="bazarr_files_count">
+        <item quantity="one">%d file</item>
+        <item quantity="other">%d files</item>
+    </plurals>
+    <plurals name="bazarr_missing_count">
+        <item quantity="one">%d missing subtitle</item>
+        <item quantity="other">%d missing subtitles</item>
+    </plurals>
+    <plurals name="bazarr_embedded_count">
+        <item quantity="one">%d Embedded Subtitle</item>
+        <item quantity="other">%d Embedded Subtitles</item>
+    </plurals>
+    <plurals name="bazarr_series_subtitle_count">
+        <item quantity="one">%1$d / %2$d episode</item>
+        <item quantity="other">%1$d / %2$d episodes</item>
+    </plurals>
+    <plurals name="bazarr_movie_subtitles_count">
+        <item quantity="one">%d Subtitle</item>
+        <item quantity="other">%d Subtitles</item>
+    </plurals>
+    <plurals name="bazarr_movie_missing_count">
+        <item quantity="one">%d Missing</item>
+        <item quantity="other">%d Missing</item>
+    </plurals>
 </resources>

--- a/shared/src/commonMain/moko-resources/base/strings.xml
+++ b/shared/src/commonMain/moko-resources/base/strings.xml
@@ -352,7 +352,6 @@
     <string name="audiobook_info_authors">Author(s)</string>
     <string name="audiobook_info_narrators">Narrator(s)</string>
     <string name="narrated_by">Narrated by: %1$s</string>
-    <string name="selected_count">%1$d selected</string>
     <string name="done">Done</string>
     <string name="born_on"> Born: %1$s  |  %2$s</string>
     <string name="add_to_arr">Add to %1$s</string>
@@ -681,7 +680,6 @@
     <string name="failed">Failed</string>
     <string name="seeding">Seeding</string>
     <string name="stalled">Stalled</string>
-    <string name="search_downloads">Search %1$d downloads</string>
     <string name="size">Size</string>
     <string name="progress">Progress</string>
     <string name="download_speed">Download Speed</string>
@@ -827,11 +825,7 @@
     <string name="invalid_backup_file">Invalid or corrupted backup file</string>
 
     <!-- Subtitles -->
-    <string name="bazarr_series_subtitle_count">%1$d / %2$d episodes</string>
-    <string name="bazarr_movie_subtitle_count">%1$d Subtitles, %2$d Missing</string>
-    <string name="bazarr_files_count">%1$d files</string>
-    <string name="bazarr_missing_count">%1$d missing subtitles</string>
-    <string name="bazarr_embedded_count">%1$d Embedded Subtitles</string>
+    <string name="bazarr_movie_subtitle_summary">%1$s, %2$s</string>
 
     <!-- Downloads -->
     <string name="downloading_file">Downloading %1$s</string>


### PR DESCRIPTION
Add `one`/`other` variants for strings that had hardcoded English plurals.

Convert a few bazaar strings into separate strings, add to plurals file.

Fixes https://github.com/owenlejeune/ArrMatey/issues/200


