### PR TITLE
Add model and use case unit tests

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/dashboard/DashboardDownloadClientsSection.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/dashboard/DashboardDownloadClientsSection.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.trace
 import com.dnfapps.arrmatey.arr.state.CombinedDashboardState
 import com.dnfapps.arrmatey.compose.utils.bytesAsFileSizeString
 import com.dnfapps.arrmatey.shared.MR

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteAlbumFilesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteAlbumFilesUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import app.cash.turbine.test
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeleteAlbumFilesUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+
+    private fun instance(type: InstanceType) =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = type,
+            enabled = true,
+        )
+
+    @Test
+    fun testWrongInstanceTypeEmitsError() =
+        runTest {
+            val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+            val repository = ArrInstanceRepository(instance(InstanceType.Sonarr), HttpClient(mockEngine), logger)
+            val useCase = DeleteAlbumFilesUseCase()
+
+            useCase(artistId = 1, albumId = 2, repository = repository).test {
+                assertTrue(awaitItem() is OperationStatus.InProgress)
+                val error = awaitItem()
+                assertTrue(error is OperationStatus.Error)
+                assertEquals("Not a Lidarr instance", error.message)
+                awaitComplete()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteAudiobookFileUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteAudiobookFileUseCaseTest.kt
@@ -1,0 +1,53 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import app.cash.turbine.test
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DeleteAudiobookFileUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+
+    private fun instance(type: InstanceType) =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = type,
+            enabled = true,
+        )
+
+    @Test
+    fun testWrongInstanceTypeEmitsError() =
+        runTest {
+            val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+            val repository = ArrInstanceRepository(instance(InstanceType.Radarr), HttpClient(mockEngine), logger)
+            val useCase = DeleteAudiobookFileUseCase()
+
+            useCase(
+                audiobookId = 99,
+                fileIds = listOf(1L, 2L, 3L),
+                repository = repository,
+            ).test {
+                assertTrue(awaitItem() is OperationStatus.InProgress)
+                val error = awaitItem()
+                assertTrue(error is OperationStatus.Error)
+                assertNotNull(error.message)
+                assertEquals("Not a Listenarr instance", error.message)
+                awaitComplete()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteBookFilesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteBookFilesUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import app.cash.turbine.test
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeleteBookFilesUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+
+    private fun instance(type: InstanceType) =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = type,
+            enabled = true,
+        )
+
+    @Test
+    fun testWrongInstanceTypeEmitsError() =
+        runTest {
+            val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+            val repository = ArrInstanceRepository(instance(InstanceType.Sonarr), HttpClient(mockEngine), logger)
+            val useCase = DeleteBookFilesUseCase()
+
+            useCase(bookFileIds = listOf(1, 2, 3), repository = repository).test {
+                assertTrue(awaitItem() is OperationStatus.InProgress)
+                val error = awaitItem()
+                assertTrue(error is OperationStatus.Error)
+                assertEquals("Not a Readarr instance", error.message)
+                awaitComplete()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteEpisodeFileUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteEpisodeFileUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import app.cash.turbine.test
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class DeleteEpisodeFileUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+
+    private fun instance(type: InstanceType) =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = type,
+            enabled = true,
+        )
+
+    @Test
+    fun testWrongInstanceTypeEmitsError() =
+        runTest {
+            val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+            val repository = ArrInstanceRepository(instance(InstanceType.Radarr), HttpClient(mockEngine), logger)
+            val useCase = DeleteEpisodeFileUseCase()
+
+            useCase(seriesId = 7, episodeFileId = 42, repository = repository).test {
+                assertTrue(awaitItem() is OperationStatus.InProgress)
+                val error = awaitItem()
+                assertTrue(error is OperationStatus.Error)
+                assertNotNull(error.message)
+                assertEquals("Not a Sonarr instance", error.message)
+                awaitComplete()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteMovieFileUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteMovieFileUseCaseTest.kt
@@ -1,0 +1,51 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import app.cash.turbine.test
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeleteMovieFileUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+
+    private fun instance(type: InstanceType) =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = type,
+            enabled = true,
+        )
+
+    @Test
+    fun testWrongInstanceTypeEmitsError() =
+        runTest {
+            val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+            val repository = ArrInstanceRepository(instance(InstanceType.Sonarr), HttpClient(mockEngine), logger)
+            val useCase = DeleteMovieFileUseCase()
+
+            useCase(
+                movieId = 123,
+                movieFileId = 456,
+                repository = repository,
+            ).test {
+                assertTrue(awaitItem() is OperationStatus.InProgress)
+                val error = awaitItem()
+                assertTrue(error is OperationStatus.Error)
+                assertEquals("Not a Radarr instance", error.message)
+                awaitComplete()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteSeasonFilesUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/DeleteSeasonFilesUseCaseTest.kt
@@ -1,0 +1,47 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import app.cash.turbine.test
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.arrmatey.model.OperationStatus
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DeleteSeasonFilesUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+
+    private fun instance(type: InstanceType) =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = type,
+            enabled = true,
+        )
+
+    @Test
+    fun testWrongInstanceTypeEmitsError() =
+        runTest {
+            val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+            val repository = ArrInstanceRepository(instance(InstanceType.Radarr), HttpClient(mockEngine), logger)
+            val useCase = DeleteSeasonFilesUseCase()
+
+            useCase(seriesId = 7, seasonNumber = 1, repository = repository).test {
+                assertTrue(awaitItem() is OperationStatus.InProgress)
+                val error = awaitItem()
+                assertTrue(error is OperationStatus.Error)
+                assertEquals("Not a Sonarr instance", error.message)
+                awaitComplete()
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/PerformRefreshUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/PerformRefreshUseCaseTest.kt
@@ -1,0 +1,57 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+
+class PerformRefreshUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+    private val useCase = PerformRefreshUseCase()
+
+    private fun repository(): ArrInstanceRepository {
+        val instance =
+            Instance(
+                id = 1,
+                label = "Test",
+                url = "http://localhost",
+                apiKey = EncryptedString("k"),
+                type = InstanceType.Sonarr,
+                enabled = true,
+            )
+        val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+        return ArrInstanceRepository(instance, HttpClient(mockEngine), logger)
+    }
+
+    @Test
+    fun testUnsupportedTypeThrows() =
+        runTest {
+            assertFailsWith<UnsupportedOperationException> {
+                useCase(mediaId = 1, type = InstanceType.Seerr, repository = repository())
+            }
+        }
+
+    @Test
+    fun testBulkRefreshUnsupportedTypeThrows() =
+        runTest {
+            assertFailsWith<UnsupportedOperationException> {
+                useCase.bulkRefresh(ids = listOf(1, 2), type = InstanceType.Bazarr, repository = repository())
+            }
+        }
+
+    @Test
+    fun testProwlarrRefreshThrows() =
+        runTest {
+            assertFailsWith<UnsupportedOperationException> {
+                useCase(mediaId = 1, type = InstanceType.Prowlarr, repository = repository())
+            }
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/ToggleMonitorUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/arr/usecase/ToggleMonitorUseCaseTest.kt
@@ -1,0 +1,103 @@
+package com.dnfapps.arrmatey.arr.usecase
+
+import com.dnfapps.arrmatey.arr.api.model.ArrAlbum
+import com.dnfapps.arrmatey.arr.api.model.Audiobook
+import com.dnfapps.arrmatey.arr.api.model.Book
+import com.dnfapps.arrmatey.arr.api.model.Episode
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import com.dnfapps.arrmatey.instances.repository.ArrInstanceRepository
+import com.dnfapps.networking.NetworkResult
+import dev.shivathapaa.logger.api.LoggerFactory
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ToggleMonitorUseCaseTest {
+    private val logger = LoggerFactory.get("test")
+    private val useCase = ToggleMonitorUseCase()
+
+    private fun repository(type: InstanceType): ArrInstanceRepository {
+        val instance =
+            Instance(
+                id = 1,
+                label = "Test",
+                url = "http://localhost",
+                apiKey = EncryptedString("k"),
+                type = type,
+                enabled = true,
+            )
+        val mockEngine = MockEngine { respond("", HttpStatusCode.OK) }
+        return ArrInstanceRepository(instance, HttpClient(mockEngine), logger)
+    }
+
+    @Test
+    fun testToggleSeasonOnWrongInstanceReturnsError() =
+        runTest {
+            val result = useCase.toggleSeason(seriesId = 1, seasonNumber = 2, repository = repository(InstanceType.Radarr))
+            assertTrue(result is NetworkResult.Error)
+            assertEquals("Not a Sonarr instance", result.message)
+        }
+
+    @Test
+    fun testToggleEpisodeOnWrongInstanceReturnsError() =
+        runTest {
+            val episode =
+                Episode(
+                    id = 1,
+                    seriesId = 1,
+                    tvdbId = null,
+                    episodeFileId = null,
+                    seasonNumber = 1,
+                    episodeNumber = 1,
+                    runtime = null,
+                    hasFile = false,
+                    monitored = false,
+                    unverifiedSceneNumbering = false,
+                )
+            val result = useCase.toggleEpisode(episode = episode, repository = repository(InstanceType.Radarr))
+            assertTrue(result is NetworkResult.Error)
+            assertEquals("Not a Sonarr instance", result.message)
+        }
+
+    @Test
+    fun testToggleAlbumOnWrongInstanceReturnsError() =
+        runTest {
+            val album =
+                ArrAlbum(
+                    id = 1,
+                    artistId = 1,
+                    foreignAlbumId = "abc",
+                    anyReleaseOk = false,
+                    profileId = 1,
+                    duration = 0,
+                )
+            val result = useCase.toggleAlbum(album = album, repository = repository(InstanceType.Sonarr))
+            assertTrue(result is NetworkResult.Error)
+            assertEquals("Not a Lidarr instance", result.message)
+        }
+
+    @Test
+    fun testToggleBookOnWrongInstanceReturnsError() =
+        runTest {
+            val book = Book(id = 1, title = "Book")
+            val result = useCase.toggleBook(book = book, repository = repository(InstanceType.Sonarr))
+            assertTrue(result is NetworkResult.Error)
+            assertEquals("Not a Readarr instance", result.message)
+        }
+
+    @Test
+    fun testToggleAudiobookOnWrongInstanceReturnsError() =
+        runTest {
+            val audiobook = Audiobook(id = 1, title = "Audio")
+            val result = useCase.toggleAudiobook(audiobook = audiobook, repository = repository(InstanceType.Sonarr))
+            assertTrue(result is NetworkResult.Error)
+            assertEquals("Not a Listenarr instance", result.message)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/AddSheetUiStateTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/AddSheetUiStateTest.kt
@@ -1,0 +1,42 @@
+package com.dnfapps.arrmatey.model
+
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class AddSheetUiStateTest {
+    @Test
+    fun testDefaultConstructorProducesEmptyState() {
+        val state = AddSheetUiState()
+        assertNull(state.targetInstance)
+        assertTrue(state.qualityProfiles.isEmpty())
+        assertTrue(state.rootFolders.isEmpty())
+        assertTrue(state.tags.isEmpty())
+        assertTrue(state.availableInstances.isEmpty())
+    }
+
+    @Test
+    fun testSecondaryConstructorForIosMatchesDefaults() {
+        val iosStyle = AddSheetUiState()
+        val explicit = AddSheetUiState(targetInstance = null)
+        assertEquals(explicit, iosStyle)
+    }
+
+    @Test
+    fun testTargetInstanceRetained() {
+        val instance =
+            Instance(
+                id = 1,
+                label = "Radarr",
+                url = "http://localhost:7878",
+                apiKey = EncryptedString("k"),
+                type = InstanceType.Radarr,
+            )
+        val state = AddSheetUiState(targetInstance = instance)
+        assertEquals(instance, state.targetInstance)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/AppColorTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/AppColorTest.kt
@@ -1,0 +1,18 @@
+package com.dnfapps.arrmatey.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AppColorTest {
+    @Test
+    fun testAllEntriesExposeResource() {
+        AppColor.entries.forEach { assertNotNull(it.resource) }
+    }
+
+    @Test
+    fun testExpectedEntries() {
+        val names = AppColor.entries.map { it.name }
+        assertEquals(listOf("Dynamic", "ArrMatey", "Amoled"), names)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/AppThemeTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/AppThemeTest.kt
@@ -1,0 +1,18 @@
+package com.dnfapps.arrmatey.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class AppThemeTest {
+    @Test
+    fun testAllEntriesExposeResource() {
+        AppTheme.entries.forEach { assertNotNull(it.resource) }
+    }
+
+    @Test
+    fun testExpectedEntries() {
+        val names = AppTheme.entries.map { it.name }
+        assertEquals(listOf("System", "Light", "Dark"), names)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/EpisodeWrapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/EpisodeWrapperTest.kt
@@ -1,0 +1,162 @@
+package com.dnfapps.arrmatey.model
+
+import com.dnfapps.arrmatey.arr.api.model.EpisodeFile
+import com.dnfapps.arrmatey.arr.api.model.Quality
+import com.dnfapps.arrmatey.arr.api.model.QualityInfo
+import com.dnfapps.arrmatey.arr.api.model.Revision
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import com.dnfapps.arrmatey.arr.api.model.Episode as ArrEpisode
+import com.dnfapps.arrmatey.seerr.api.model.Episode as SeerrEpisode
+
+class EpisodeWrapperTest {
+    private fun arrEpisode(
+        seasonNumber: Int = 1,
+        episodeNumber: Int = 3,
+        title: String? = "Arr Title",
+        overview: String? = "Arr overview",
+        monitored: Boolean = true,
+        hasFile: Boolean = false,
+        airDate: LocalDate? = LocalDate(2020, 1, 15),
+        file: EpisodeFile? = null,
+    ) = ArrEpisode(
+        id = 42,
+        seriesId = 7,
+        tvdbId = null,
+        episodeFileId = file?.id,
+        seasonNumber = seasonNumber,
+        episodeNumber = episodeNumber,
+        title = title,
+        airDate = airDate,
+        runtime = 30,
+        overview = overview,
+        episodeFile = file,
+        hasFile = hasFile,
+        monitored = monitored,
+        unverifiedSceneNumbering = false,
+    )
+
+    private fun seerrEpisode(
+        seasonNumber: Int = 2,
+        episodeNumber: Int = 5,
+        name: String = "Seerr Name",
+        overview: String? = "Seerr overview",
+        stillPath: String? = "/still.jpg",
+    ) = SeerrEpisode(
+        id = 100,
+        name = name,
+        airDate = null,
+        episodeNumber = episodeNumber,
+        overview = overview,
+        seasonNumber = seasonNumber,
+        showId = 1,
+        stillPath = stillPath,
+    )
+
+    @Test
+    fun testPrefersArrEpisodeForNumbersAndTitle() {
+        val wrapper = EpisodeWrapper(arrEpisode = arrEpisode(), seerrEpisode = seerrEpisode())
+        assertEquals(1, wrapper.seasonNumber)
+        assertEquals(3, wrapper.episodeNumber)
+        assertEquals("Arr Title", wrapper.title)
+        assertEquals("Arr overview", wrapper.overview)
+    }
+
+    @Test
+    fun testFallsBackToSeerrEpisodeWhenArrMissing() {
+        val wrapper = EpisodeWrapper(seerrEpisode = seerrEpisode())
+        assertEquals(2, wrapper.seasonNumber)
+        assertEquals(5, wrapper.episodeNumber)
+        assertEquals("Seerr Name", wrapper.title)
+        assertEquals("Seerr overview", wrapper.overview)
+    }
+
+    @Test
+    fun testDefaultsWhenNoEpisodesProvided() {
+        val wrapper = EpisodeWrapper()
+        assertEquals(0, wrapper.seasonNumber)
+        assertEquals(0, wrapper.episodeNumber)
+        assertNull(wrapper.title)
+        assertNull(wrapper.overview)
+        assertNull(wrapper.stillPath)
+        assertNull(wrapper.airDate)
+        assertNull(wrapper.monitored)
+        assertFalse(wrapper.isMonitored)
+        assertFalse(wrapper.hasFile)
+        assertNull(wrapper.fileQualityName)
+        assertFalse(wrapper.isActive)
+    }
+
+    @Test
+    fun testStillPathPrefersSeerr() {
+        val wrapper =
+            EpisodeWrapper(
+                arrEpisode = arrEpisode(),
+                seerrEpisode = seerrEpisode(stillPath = "/seerr.jpg"),
+            )
+        assertEquals("/seerr.jpg", wrapper.stillPath)
+    }
+
+    @Test
+    fun testStillPathFallsBackWhenSeerrNull() {
+        val wrapper = EpisodeWrapper(seerrEpisode = seerrEpisode(stillPath = null))
+        assertNull(wrapper.stillPath)
+    }
+
+    @Test
+    fun testAirDatePrefersArrEpisode() {
+        val wrapper = EpisodeWrapper(arrEpisode = arrEpisode(airDate = LocalDate(2021, 6, 1)))
+        assertEquals(LocalDate(2021, 6, 1), wrapper.airDate)
+    }
+
+    @Test
+    fun testMonitoredReflectsArrEpisode() {
+        val monitored = EpisodeWrapper(arrEpisode = arrEpisode(monitored = true))
+        assertEquals(true, monitored.monitored)
+        assertTrue(monitored.isMonitored)
+
+        val unmonitored = EpisodeWrapper(arrEpisode = arrEpisode(monitored = false))
+        assertEquals(false, unmonitored.monitored)
+        assertFalse(unmonitored.isMonitored)
+    }
+
+    @Test
+    fun testHasFileMatchesArrEpisode() {
+        val withFile = EpisodeWrapper(arrEpisode = arrEpisode(hasFile = true))
+        assertTrue(withFile.hasFile)
+
+        val withoutFile = EpisodeWrapper(arrEpisode = arrEpisode(hasFile = false))
+        assertFalse(withoutFile.hasFile)
+    }
+
+    @Test
+    fun testFileQualityNameFromEpisodeFile() {
+        val file =
+            EpisodeFile(
+                id = 1,
+                relativePath = "e.mkv",
+                size = 100,
+                qualityCutoffNotMet = false,
+                quality =
+                    QualityInfo(
+                        quality = Quality(id = 1, name = "1080p"),
+                        revision = Revision(version = 1, real = 0, isRepack = false),
+                    ),
+                seriesId = 7,
+                seasonNumber = 1,
+            )
+        val wrapper = EpisodeWrapper(arrEpisode = arrEpisode(file = file, hasFile = true))
+        assertEquals("1080p", wrapper.fileQualityName)
+    }
+
+    @Test
+    fun testActivityProgressStoredAsProvided() {
+        val wrapper = EpisodeWrapper(isActive = true, activityProgress = "42%")
+        assertTrue(wrapper.isActive)
+        assertEquals("42%", wrapper.activityProgress)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/InstanceMediaPresenceTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/InstanceMediaPresenceTest.kt
@@ -1,0 +1,45 @@
+package com.dnfapps.arrmatey.model
+
+import com.dnfapps.arrmatey.arr.api.model.MockMedia
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.instances.model.Instance
+import com.dnfapps.arrmatey.instances.model.InstanceType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class InstanceMediaPresenceTest {
+    private val instance =
+        Instance(
+            id = 1,
+            label = "Test",
+            url = "http://localhost",
+            apiKey = EncryptedString("k"),
+            type = InstanceType.Sonarr,
+        )
+
+    @Test
+    fun testIsPresentWhenArrMediaHasNonZeroId() {
+        val presence = InstanceMediaPresence(instance = instance, arrMedia = MockMedia.Sonarr)
+        assertTrue(presence.isPresent)
+    }
+
+    @Test
+    fun testIsNotPresentWhenArrMediaIsNull() {
+        val presence = InstanceMediaPresence(instance = instance, arrMedia = null)
+        assertFalse(presence.isPresent)
+    }
+
+    @Test
+    fun testExplicitIsPresentOverride() {
+        val presence = InstanceMediaPresence(instance = instance, arrMedia = null, isPresent = true)
+        assertTrue(presence.isPresent)
+    }
+
+    @Test
+    fun testInstanceReferenceRetained() {
+        val presence = InstanceMediaPresence(instance = instance)
+        assertEquals(instance, presence.instance)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/OperationStatusTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/OperationStatusTest.kt
@@ -1,0 +1,77 @@
+package com.dnfapps.arrmatey.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+class OperationStatusTest {
+    @Test
+    fun testIdleIsSingleton() {
+        assertSame(OperationStatus.Idle, OperationStatus.Idle)
+    }
+
+    @Test
+    fun testInProgressIsSingleton() {
+        assertSame(OperationStatus.InProgress, OperationStatus.InProgress)
+    }
+
+    @Test
+    fun testSuccessDefaults() {
+        val success = OperationStatus.Success()
+        assertNull(success.message)
+        assertNull(success.result)
+    }
+
+    @Test
+    fun testSuccessCarriesMessageAndResult() {
+        val success = OperationStatus.Success(message = "ok", result = 42)
+        assertEquals("ok", success.message)
+        assertEquals(42, success.result)
+    }
+
+    @Test
+    fun testSuccessEquality() {
+        val a = OperationStatus.Success(message = "done", result = "payload")
+        val b = OperationStatus.Success(message = "done", result = "payload")
+        val c = OperationStatus.Success(message = "different")
+        assertEquals(a, b)
+        assertNotEquals(a, c)
+    }
+
+    @Test
+    fun testErrorDefaults() {
+        val error = OperationStatus.Error()
+        assertNull(error.code)
+        assertNull(error.message)
+        assertNull(error.cause)
+    }
+
+    @Test
+    fun testErrorCarriesFields() {
+        val cause = IllegalStateException("boom")
+        val error = OperationStatus.Error(code = 500, message = "failure", cause = cause)
+        assertEquals(500, error.code)
+        assertEquals("failure", error.message)
+        assertSame(cause, error.cause)
+    }
+
+    @Test
+    fun testDistinctSubtypesAreNotEqual() {
+        assertNotEquals<OperationStatus>(OperationStatus.Idle, OperationStatus.InProgress)
+        assertNotEquals<OperationStatus>(OperationStatus.Success(), OperationStatus.Error())
+    }
+
+    @Test
+    fun testSealedInterfaceHierarchy() {
+        val statuses: List<OperationStatus> =
+            listOf(
+                OperationStatus.Idle,
+                OperationStatus.InProgress,
+                OperationStatus.Success(),
+                OperationStatus.Error(),
+            )
+        assertEquals(4, statuses.size)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/SeasonWrapperTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/SeasonWrapperTest.kt
@@ -1,0 +1,199 @@
+package com.dnfapps.arrmatey.model
+
+import com.dnfapps.arrmatey.arr.api.model.SeasonStatistics
+import kotlinx.datetime.LocalDate
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+import com.dnfapps.arrmatey.arr.api.model.Season as ArrSeason
+import com.dnfapps.arrmatey.seerr.api.model.Season as SeerrSeason
+
+class SeasonWrapperTest {
+    private fun arrSeason(
+        seasonNumber: Int = 1,
+        monitored: Boolean = true,
+        statistics: SeasonStatistics? = null,
+    ) = ArrSeason(
+        seasonNumber = seasonNumber,
+        monitored = monitored,
+        statistics = statistics,
+    )
+
+    private fun seerrSeason(
+        seasonNumber: Int = 1,
+        name: String = "Indigo League",
+        airDate: LocalDate? = LocalDate(1997, 4, 1),
+        episodeCount: Int = 82,
+    ) = SeerrSeason(
+        id = 1,
+        seasonNumber = seasonNumber,
+        name = name,
+        airDate = airDate,
+        episodeCount = episodeCount,
+    )
+
+    private fun stats(
+        totalEpisodeCount: Int = 10,
+        episodeFileCount: Int = 5,
+        sizeOnDisk: Long = 0,
+    ) = SeasonStatistics(
+        episodeFileCount = episodeFileCount,
+        episodeCount = totalEpisodeCount,
+        totalEpisodeCount = totalEpisodeCount,
+        sizeOnDisk = sizeOnDisk,
+        percentOfEpisodes = 100.0,
+    )
+
+    @Test
+    fun testTotalEpisodeCountPrefersArrStatistics() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                arrSeason = arrSeason(statistics = stats(totalEpisodeCount = 12)),
+                seerrSeason = seerrSeason(episodeCount = 8),
+                episodes = List(3) { EpisodeWrapper() },
+            )
+        assertEquals(12, wrapper.totalEpisodeCount)
+    }
+
+    @Test
+    fun testTotalEpisodeCountFallsBackToSeerr() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                seerrSeason = seerrSeason(episodeCount = 8),
+                episodes = List(3) { EpisodeWrapper() },
+            )
+        assertEquals(8, wrapper.totalEpisodeCount)
+    }
+
+    @Test
+    fun testTotalEpisodeCountFallsBackToEpisodesSize() {
+        val wrapper = SeasonWrapper(seasonNumber = 1, episodes = List(4) { EpisodeWrapper() })
+        assertEquals(4, wrapper.totalEpisodeCount)
+    }
+
+    @Test
+    fun testEpisodeFileCountReadsFromArrStatistics() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                arrSeason = arrSeason(statistics = stats(episodeFileCount = 7)),
+            )
+        assertEquals(7, wrapper.episodeFileCount)
+    }
+
+    @Test
+    fun testEpisodeFileCountNullWithoutArrSeason() {
+        val wrapper = SeasonWrapper(seasonNumber = 1, seerrSeason = seerrSeason())
+        assertNull(wrapper.episodeFileCount)
+    }
+
+    @Test
+    fun testActiveEpisodeCount() {
+        val episodes =
+            listOf(
+                EpisodeWrapper(isActive = true),
+                EpisodeWrapper(isActive = false),
+                EpisodeWrapper(isActive = true),
+                EpisodeWrapper(isActive = true),
+            )
+        val wrapper = SeasonWrapper(seasonNumber = 1, episodes = episodes)
+        assertEquals(3, wrapper.activeEpisodeCount)
+    }
+
+    @Test
+    fun testMonitoredFlagsReflectArrSeason() {
+        val monitored = SeasonWrapper(seasonNumber = 1, arrSeason = arrSeason(monitored = true))
+        assertTrue(monitored.hasArrSeason)
+        assertEquals(true, monitored.monitored)
+        assertTrue(monitored.isMonitored)
+
+        val unmonitored = SeasonWrapper(seasonNumber = 1, arrSeason = arrSeason(monitored = false))
+        assertEquals(false, unmonitored.monitored)
+        assertFalse(unmonitored.isMonitored)
+    }
+
+    @Test
+    fun testMonitoredIsNullAndFalseWithoutArrSeason() {
+        val wrapper = SeasonWrapper(seasonNumber = 1, seerrSeason = seerrSeason())
+        assertFalse(wrapper.hasArrSeason)
+        assertNull(wrapper.monitored)
+        assertFalse(wrapper.isMonitored)
+    }
+
+    @Test
+    fun testCustomTitleReturnsTrimmedName() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                seerrSeason = seerrSeason(name = "  Indigo League  "),
+            )
+        assertEquals("Indigo League", wrapper.customTitle)
+    }
+
+    @Test
+    fun testCustomTitleNullWhenNameMatchesSeasonNumber() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 2,
+                seerrSeason = seerrSeason(seasonNumber = 2, name = "Season 2"),
+            )
+        assertNull(wrapper.customTitle)
+    }
+
+    @Test
+    fun testCustomTitleNullForSpecialsInSeasonZero() {
+        val specials =
+            SeasonWrapper(
+                seasonNumber = 0,
+                seerrSeason = seerrSeason(seasonNumber = 0, name = "Specials"),
+            )
+        assertNull(specials.customTitle)
+
+        val seasonZero =
+            SeasonWrapper(
+                seasonNumber = 0,
+                seerrSeason = seerrSeason(seasonNumber = 0, name = "Season 0"),
+            )
+        assertNull(seasonZero.customTitle)
+    }
+
+    @Test
+    fun testCustomTitleNullWhenNoSeerrSeason() {
+        val wrapper = SeasonWrapper(seasonNumber = 1, arrSeason = arrSeason())
+        assertNull(wrapper.customTitle)
+    }
+
+    @Test
+    fun testYearFromSeerrAirDateWhenNoEpisodeDates() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                seerrSeason = seerrSeason(airDate = LocalDate(2005, 6, 1)),
+            )
+        assertEquals("2005", wrapper.year)
+    }
+
+    @Test
+    fun testInfoStringJoinsAvailableFields() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                seerrSeason = seerrSeason(name = "Indigo League", airDate = LocalDate(1997, 4, 1)),
+            )
+        assertEquals("Indigo League • 1997", wrapper.infoString)
+    }
+
+    @Test
+    fun testNameExposesSeerrName() {
+        val wrapper =
+            SeasonWrapper(
+                seasonNumber = 1,
+                seerrSeason = seerrSeason(name = "Indigo League"),
+            )
+        assertEquals("Indigo League", wrapper.name)
+    }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/SmartAddSeerrActionTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/model/SmartAddSeerrActionTest.kt
@@ -1,0 +1,23 @@
+package com.dnfapps.arrmatey.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+
+class SmartAddSeerrActionTest {
+    @Test
+    fun testDefaultIsAlwaysAsk() {
+        assertEquals(SmartAddSeerrAction.AlwaysAsk, SmartAddSeerrAction.default)
+    }
+
+    @Test
+    fun testAllEntriesExposeResource() {
+        SmartAddSeerrAction.entries.forEach { assertNotNull(it.resource) }
+    }
+
+    @Test
+    fun testAllExpectedEntriesPresent() {
+        val names = SmartAddSeerrAction.entries.map { it.name }.toSet()
+        assertEquals(setOf("Approve", "Decline", "AlwaysAsk"), names)
+    }
+}


### PR DESCRIPTION
Extends shared-module test coverage:

* Models: `OperationStatus`, `InstanceMediaPresence`, `EpisodeWrapper`, `AddSheetUiState`, `SmartAddSeerrAction`, `AppTheme`, `AppColor`: sealed hierarchy, equality, computed properties, arr/seerr fallback logic, enum defaults.

* Use cases: `PerformRefreshUseCase` (unsupported `InstanceType` throws on both `invoke` and `bulkRefresh`), `ToggleMonitorUseCase` (season/episode/album/book/audiobook error propagation on mismatched instance type), and `Delete{Episode,Movie,Album,Season,Book}File(s)UseCase` (flow emits `InProgress` → `Error` with the correct guard message when the caller supplies a wrong-type repository).

Also remove an unused import in`DashboardDownloadClientsSection.kt`

Related to https://github.com/owenlejeune/ArrMatey/issues/174
 