### PR TITLE
fix(android): align search app bar with status bar inset

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/ArrAppBarWithSearch.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/components/ArrAppBarWithSearch.kt
@@ -7,7 +7,10 @@ import androidx.compose.animation.shrinkOut
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.asPaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.clearText
 import androidx.compose.material.icons.Icons
@@ -31,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import com.dnfapps.arrmatey.entensions.isCollapsed
 import com.dnfapps.arrmatey.entensions.isExpanded
 import com.dnfapps.arrmatey.shared.MR
@@ -127,6 +131,8 @@ fun ArrAppBarWithSearch(
         colors = colors,
         inputField = inputField,
         modifier = modifier.fillMaxWidth(),
+        contentPadding = WindowInsets.statusBars.asPaddingValues(),
+        windowInsets = WindowInsets(0.dp),
         navigationIcon = {
             AnimatedVisibility(
                 visible = searchBarState.isCollapsed(),

--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrLibraryScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrLibraryScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
@@ -316,7 +315,7 @@ fun ArrLibraryScreen(
                 }
             }
         },
-        contentWindowInsets = WindowInsets.statusBars,
+        contentWindowInsets = WindowInsets(0.dp),
     ) { paddingValues ->
         Box(
             modifier =


### PR DESCRIPTION
## Description

- Paint the search app bar surface across the status-bar inset.
- Move the status-bar spacing into `AppBarWithSearch` so its dynamic container color also covers that area.
- Remove the duplicate scaffold inset from the Library screen.

This addresses the dark-theme black band reported on a physical Samsung device. The change is limited to the Android UI path.

## Related Issue

Fixes #224

## Type of Change

- [x] fix: Bug fix

## Scope

- [x] Small change / bug fix (targets `main`)

## Platforms / Modules Touched

- [x] Android UI

## UI Changes

- [x] Android UI updated

The before/after screenshots are attached in issue #224 and are intentionally not committed to the repository.

## Implementation Notes

`AppBarWithSearch` now receives the status-bar padding as content padding while its own window insets are disabled. This keeps the app-bar surface and its dynamic color calculation continuous through the inset. `ArrLibraryScreen` supplies zero content window insets to avoid applying the status-bar inset twice.

## Breaking Changes

- [x] No breaking changes

## Testing

- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :composeApp:assembleDebug`
- `JAVA_HOME=/opt/homebrew/opt/openjdk@21 ./gradlew :composeApp:testDebugUnitTest`

Both commands pass. The candidate APK was also built for package-level side-by-side installation; final physical-device validation can follow review.

## Checklist

- [x] Linked to an approved issue
- [x] Target branch is correct (`main`)
- [x] Code follows Kotlin style guidelines
- [x] No unrelated changes included in this PR
