### PR TITLE
Use distinct keys in `ArrLibraryScreen`

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrLibraryScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/dnfapps/arrmatey/ui/screens/ArrLibraryScreen.kt
@@ -139,8 +139,8 @@ fun ArrLibraryScreen(
     wideRailIsVisible: Boolean = false,
     onNavigateToSearch: (String, InstanceType, Long?) -> Unit,
     onNavigateToDetails: (ArrMedia, Long?) -> Unit,
-    arrMediaViewModel: ArrMediaViewModel = koinViewModel(key = type.name, parameters = { parametersOf(type) }),
-    instancesViewModel: InstancesViewModel = koinViewModel(key = type.name, parameters = { parametersOf(type) }),
+    arrMediaViewModel: ArrMediaViewModel = koinViewModel(key = "arrMedia_${type.name}", parameters = { parametersOf(type) }),
+    instancesViewModel: InstancesViewModel = koinViewModel(key = "instances_${type.name}", parameters = { parametersOf(type) }),
     globalPreferencesStore: PreferencesStore = koinInject(),
 ) {
     val context = LocalContext.current
@@ -325,12 +325,18 @@ fun ArrLibraryScreen(
                     .fillMaxSize(),
             contentAlignment = Alignment.Center,
         ) {
-            if (instancesState.selectedInstance == null) {
+            if (instancesState.instances.isEmpty()) {
                 NoInstanceView(type)
+            } else if (instancesState.selectedInstance == null) {
+                LoadingIndicator(
+                    modifier = Modifier.size(96.dp),
+                )
             } else {
                 when (val state = uiState) {
                     is ArrLibrary.Initial -> {
-                        NoInstanceView(type)
+                        LoadingIndicator(
+                            modifier = Modifier.size(96.dp),
+                        )
                     }
 
                     is ArrLibrary.Loading -> {

--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/instances/repository/InstanceManager.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/instances/repository/InstanceManager.kt
@@ -65,8 +65,12 @@ class InstanceManager(
 
         instances.forEach { instance ->
             if (!currentRepos.containsKey(instance.id)) {
-                val httpClient = httpClientFactory.create(instance)
-                currentRepos[instance.id] = createScopedRepository(instance, httpClient, logger)
+                try {
+                    val httpClient = httpClientFactory.create(instance)
+                    currentRepos[instance.id] = createScopedRepository(instance, httpClient, logger)
+                } catch (e: Exception) {
+                    logger.error(e) { "Failed to create repository for instance ${instance.id} (${instance.type}): ${instance.label}" }
+                }
             }
         }
 


### PR DESCRIPTION
Give `ArrMediaViewModel` and `InstancesViewModel` distinct keys in `ArrLibraryScreen` instead of both using `type.name`.

Also show `NoInstanceView` only when the instance list is empty; show the loading indicator when loading.

Have `InstanceManager` log failures.
  
Fixes https://github.com/owenlejeune/ArrMatey/issues/225
