### PR TITLE
Fix transmission and add tests

### DIFF
--- a/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/api/TransmissionClient.kt
+++ b/shared/src/commonMain/kotlin/com/dnfapps/arrmatey/downloadclient/api/TransmissionClient.kt
@@ -12,11 +12,14 @@ import com.dnfapps.networking.NetworkResult
 import com.dnfapps.networking.safeCall
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.request.basicAuth
 import io.ktor.client.request.header
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
 import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
@@ -187,27 +190,19 @@ class TransmissionClient(
             )
 
         return httpClient.safeCall {
+            // A missing or stale session id returns 409 with the id to echo back, thrown when expectSuccess is enabled.
             val firstResponse =
-                post("transmission/rpc") {
-                    contentType(ContentType.Application.Json)
-                    basicAuth(downloadClient.username.value, downloadClient.password.value)
-                    if (sessionId.isNotEmpty()) {
-                        header(HEADER_SESSION_ID, sessionId)
-                    }
-                    setBody(request)
+                try {
+                    postRpc(request)
+                } catch (e: ClientRequestException) {
+                    if (e.response.status != HttpStatusCode.Conflict) throw e
+                    e.response
                 }
 
             val response =
-                if (firstResponse.status.value == 409) {
+                if (firstResponse.status == HttpStatusCode.Conflict) {
                     sessionId = firstResponse.headers[HEADER_SESSION_ID].orEmpty()
-                    post("transmission/rpc") {
-                        contentType(ContentType.Application.Json)
-                        basicAuth(downloadClient.username.value, downloadClient.password.value)
-                        if (sessionId.isNotEmpty()) {
-                            header(HEADER_SESSION_ID, sessionId)
-                        }
-                        setBody(request)
-                    }
+                    postRpc(request)
                 } else {
                     firstResponse
                 }
@@ -215,6 +210,16 @@ class TransmissionClient(
             response.body<TransmissionRpcResponse<T>>()
         }
     }
+
+    private suspend fun HttpClient.postRpc(request: TransmissionRpcRequest): HttpResponse =
+        post("transmission/rpc") {
+            contentType(ContentType.Application.Json)
+            basicAuth(downloadClient.username.value, downloadClient.password.value)
+            if (sessionId.isNotEmpty()) {
+                header(HEADER_SESSION_ID, sessionId)
+            }
+            setBody(request)
+        }
 
     private fun String.toTransmissionId(): JsonPrimitive {
         val intId = toIntOrNull()

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/TransmissionClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/TransmissionClientTest.kt
@@ -1,0 +1,91 @@
+package com.dnfapps.arrmatey.downloadclient.api
+
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClient
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClientType
+import com.dnfapps.networking.NetworkResult
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val HEADER_SESSION_ID = "X-Transmission-Session-Id"
+private const val SESSION_ID = "test-session-id"
+
+class TransmissionClientTest {
+    private val fakeClient =
+        DownloadClient(
+            id = 1,
+            type = DownloadClientType.Transmission,
+            label = "Test Transmission",
+            url = "http://localhost:9091",
+            username = EncryptedString("user"),
+            password = EncryptedString("pass"),
+        )
+
+    private fun httpClient(mockEngine: MockEngine) =
+        HttpClient(mockEngine) {
+            expectSuccess = true
+            install(ContentNegotiation) {
+                json(
+                    Json {
+                        ignoreUnknownKeys = true
+                    },
+                )
+            }
+        }
+
+    @Test
+    fun testConnectionRetriesWithSessionId() =
+        runTest {
+            val sessionIds = mutableListOf<String?>()
+            val mockEngine =
+                MockEngine { request ->
+                    val sessionId = request.headers[HEADER_SESSION_ID]
+                    sessionIds.add(sessionId)
+                    if (sessionId == SESSION_ID) {
+                        respond(
+                            content = """{"result":"success","arguments":{}}""",
+                            status = HttpStatusCode.OK,
+                            headers = headersOf("Content-Type", "application/json"),
+                        )
+                    } else {
+                        respond(
+                            content = "409: Conflict",
+                            status = HttpStatusCode.Conflict,
+                            headers = headersOf(HEADER_SESSION_ID, SESSION_ID),
+                        )
+                    }
+                }
+
+            val result = TransmissionClient(fakeClient, httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Success, "Expected Success but got $result")
+            assertEquals(listOf(null, SESSION_ID), sessionIds)
+        }
+
+    @Test
+    fun testConnectionReturnsErrorOnUnauthorized() =
+        runTest {
+            val mockEngine =
+                MockEngine { _ ->
+                    respond(
+                        content = "401: Unauthorized",
+                        status = HttpStatusCode.Unauthorized,
+                    )
+                }
+
+            val result = TransmissionClient(fakeClient, httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Error, "Expected Error but got $result")
+            assertEquals(HttpStatusCode.Unauthorized.value, result.code)
+        }
+}


### PR DESCRIPTION
Fix transmission by catching the exception that's thrown on the first RPC call when transmission returns 409/conflict.  Also created a new function to avoid duplication.

Add some tests for this too.

I dont have transmission so I cannot test.

Maybe fixes https://github.com/owenlejeune/ArrMatey/issues/262 ?
