### PR TITLE
Remove unused moko alias

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -122,6 +122,5 @@ kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref =
 skie = { id = "co.touchlab.skie", version.ref = "skie" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 androidx-room = { id = "androidx.room", version.ref = "room" }
-moko-resources = { id = "dev.icerock.moko.multiplatform-resources", version.ref = "moko" }
 aboutLibraries = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutLibraries" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }

--- a/renovate.json
+++ b/renovate.json
@@ -67,12 +67,6 @@
       ]
     },
     {
-      "description": "Moko plugin marker resolves from the Gradle Plugin Portal, not Maven Central",
-      "matchDatasources": ["maven"],
-      "matchPackageNames": ["/^dev\\.icerock\\.moko\\.multiplatform-resources/"],
-      "registryUrls": ["https://plugins.gradle.org/m2/"]
-    },
-    {
       "description": "kotlinx-datetime ships -0.6.x-compat builds that sort above the real release",
       "matchPackageNames": ["org.jetbrains.kotlinx:kotlinx-datetime"],
       "allowedVersions": "!/-compat$/"


### PR DESCRIPTION
Follow up to #271 to fix 

> Failed to look up maven package
> `dev.icerock.moko.multiplatform-resources:dev.icerock.moko.multiplatform-resources.gradle.plugin: no-result`

* the entry in `libs.versions.toml` is unused, so remove it
* nothing needs the Gradle Plugin Portal registryUrls rule from `renovate.json`, which doesn't work anyway (is causing the errors)

