### PR TITLE
Add download client auth and API cache tests

### DIFF
--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/DelugeClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/DelugeClientTest.kt
@@ -1,0 +1,79 @@
+package com.dnfapps.arrmatey.downloadclient.api
+
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClient
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClientType
+import com.dnfapps.networking.NetworkResult
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.content.TextContent
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class DelugeClientTest {
+    private fun client(password: String = "secret") =
+        DownloadClient(
+            id = 1,
+            type = DownloadClientType.Deluge,
+            label = "deluge",
+            url = "http://localhost:8112",
+            password = EncryptedString(password),
+        )
+
+    private fun httpClient(mockEngine: MockEngine) =
+        HttpClient(mockEngine) {
+            expectSuccess = true
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+    @Test
+    fun testConnectionAlwaysReAuthenticates() =
+        runTest {
+            // testConnection resets the auth flag so an edited password takes effect immediately.
+            val methods = mutableListOf<String>()
+            val mockEngine =
+                MockEngine { request ->
+                    val body = (request.body as? TextContent)?.text.orEmpty()
+                    if ("\"method\":\"auth.login\"" in body) methods.add("auth.login")
+                    respond(
+                        content = """{"id":1,"result":true,"error":null}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+
+            val deluge = DelugeClient(client(), httpClient(mockEngine))
+            deluge.testConnection()
+            deluge.testConnection()
+
+            assertEquals(listOf("auth.login", "auth.login"), methods)
+        }
+
+    @Test
+    fun testConnectionReturnsErrorWhenLoginRejected() =
+        runTest {
+            val mockEngine =
+                MockEngine { _ ->
+                    respond(
+                        content = """{"id":1,"result":false,"error":null}""",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+
+            val result = DelugeClient(client(), httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Error)
+            assertEquals(401, result.code)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/QBittorrentClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/QBittorrentClientTest.kt
@@ -1,0 +1,189 @@
+package com.dnfapps.arrmatey.downloadclient.api
+
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClient
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClientType
+import com.dnfapps.networking.NetworkResult
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class QBittorrentClientTest {
+    private fun client(
+        username: String = "",
+        password: String = "",
+        apiKey: String = "",
+    ) = DownloadClient(
+        id = 1,
+        type = DownloadClientType.QBittorrent,
+        label = "qb",
+        url = "http://localhost:8080",
+        username = EncryptedString(username),
+        password = EncryptedString(password),
+        apiKey = EncryptedString(apiKey),
+    )
+
+    private fun httpClient(mockEngine: MockEngine) =
+        HttpClient(mockEngine) {
+            expectSuccess = true
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+    @Test
+    fun testConnectionWithApiKeySkipsLogin() =
+        runTest {
+            val paths = mutableListOf<String>()
+            val mockEngine =
+                MockEngine { request ->
+                    paths.add(request.url.encodedPath)
+                    respond(
+                        content = "4.6.0",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                    )
+                }
+
+            val result = QBittorrentClient(client(apiKey = "key"), httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Success)
+            assertEquals(listOf("/api/v2/app/version"), paths)
+        }
+
+    @Test
+    fun testConnectionWithNoCredentialsSkipsLogin() =
+        runTest {
+            val paths = mutableListOf<String>()
+            val mockEngine =
+                MockEngine { request ->
+                    paths.add(request.url.encodedPath)
+                    respond(
+                        content = "4.6.0",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                    )
+                }
+
+            val result = QBittorrentClient(client(), httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Success)
+            assertEquals(listOf("/api/v2/app/version"), paths)
+        }
+
+    @Test
+    fun testConnectionWithCredentialsLogsInFirst() =
+        runTest {
+            val paths = mutableListOf<String>()
+            val mockEngine =
+                MockEngine { request ->
+                    paths.add(request.url.encodedPath)
+                    respond(
+                        content = "4.6.0",
+                        status = HttpStatusCode.OK,
+                        headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                    )
+                }
+
+            val result =
+                QBittorrentClient(
+                    client(username = "u", password = "p"),
+                    httpClient(mockEngine),
+                ).testConnection()
+
+            assertTrue(result is NetworkResult.Success)
+            assertEquals(listOf("/api/v2/auth/login", "/api/v2/app/version"), paths)
+        }
+
+    @Test
+    fun testGetDownloadsRetriesLoginOn401() =
+        runTest {
+            // Verifies the authenticated flag resets on 401 so an expired cookie recovers.
+            val paths = mutableListOf<String>()
+            var infoCalls = 0
+            val mockEngine =
+                MockEngine { request ->
+                    val path = request.url.encodedPath
+                    paths.add(path)
+                    when (path) {
+                        "/api/v2/auth/login" ->
+                            respond(
+                                content = "Ok.",
+                                status = HttpStatusCode.OK,
+                                headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                            )
+                        "/api/v2/torrents/info" -> {
+                            infoCalls += 1
+                            if (infoCalls == 1) {
+                                respond(content = "Forbidden", status = HttpStatusCode.Unauthorized)
+                            } else {
+                                respond(
+                                    content = "[]",
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentType, "application/json"),
+                                )
+                            }
+                        }
+                        else -> respond(content = "", status = HttpStatusCode.NotFound)
+                    }
+                }
+
+            val qb = QBittorrentClient(client(username = "u", password = "p"), httpClient(mockEngine))
+            val result = qb.getDownloads()
+
+            assertTrue(result is NetworkResult.Success)
+            assertEquals(emptyList(), result.data)
+            assertEquals(
+                listOf(
+                    "/api/v2/auth/login",
+                    "/api/v2/torrents/info",
+                    "/api/v2/auth/login",
+                    "/api/v2/torrents/info",
+                ),
+                paths,
+            )
+        }
+
+    @Test
+    fun testGetDownloadsReturnsErrorWhenReLoginFails() =
+        runTest {
+            var loginCalls = 0
+            val mockEngine =
+                MockEngine { request ->
+                    when (request.url.encodedPath) {
+                        "/api/v2/auth/login" -> {
+                            loginCalls += 1
+                            if (loginCalls == 1) {
+                                respond(
+                                    content = "Ok.",
+                                    status = HttpStatusCode.OK,
+                                    headers = headersOf(HttpHeaders.ContentType, "text/plain"),
+                                )
+                            } else {
+                                respond(content = "Fails.", status = HttpStatusCode.Forbidden)
+                            }
+                        }
+                        "/api/v2/torrents/info" ->
+                            respond(content = "Unauthorized", status = HttpStatusCode.Unauthorized)
+                        else -> respond(content = "", status = HttpStatusCode.NotFound)
+                    }
+                }
+
+            val result =
+                QBittorrentClient(client(username = "u", password = "p"), httpClient(mockEngine))
+                    .getDownloads()
+
+            assertTrue(result is NetworkResult.Error)
+            assertEquals(HttpStatusCode.Forbidden.value, result.code)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/SABnzbdClientTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/api/SABnzbdClientTest.kt
@@ -1,0 +1,95 @@
+package com.dnfapps.arrmatey.downloadclient.api
+
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClient
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClientType
+import com.dnfapps.networking.NetworkResult
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SABnzbdClientTest {
+    private val queueResponseBody = """{"queue":{"paused":false,"slots":[]}}"""
+
+    private fun client(apiKey: String = "abc123") =
+        DownloadClient(
+            id = 1,
+            type = DownloadClientType.SABnzbd,
+            label = "sab",
+            url = "http://localhost:8080",
+            apiKey = EncryptedString(apiKey),
+        )
+
+    private fun httpClient(mockEngine: MockEngine) =
+        HttpClient(mockEngine) {
+            expectSuccess = true
+            install(ContentNegotiation) {
+                json(Json { ignoreUnknownKeys = true })
+            }
+        }
+
+    @Test
+    fun testConnectionSendsCurrentApiKey() =
+        runTest {
+            var seenKey: String? = null
+            val mockEngine =
+                MockEngine { request ->
+                    seenKey = request.url.parameters["apikey"]
+                    respond(
+                        content = queueResponseBody,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+
+            val result = SABnzbdClient(client(apiKey = "abc123"), httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Success)
+            assertEquals("abc123", seenKey)
+        }
+
+    @Test
+    fun testConnectionEachCallPicksUpUpdatedApiKey() =
+        runTest {
+            // Stateless api-key auth — no cache to invalidate on edit.
+            val seenKeys = mutableListOf<String?>()
+            val mockEngine =
+                MockEngine { request ->
+                    seenKeys.add(request.url.parameters["apikey"])
+                    respond(
+                        content = queueResponseBody,
+                        status = HttpStatusCode.OK,
+                        headers = headersOf("Content-Type", "application/json"),
+                    )
+                }
+
+            val engine = httpClient(mockEngine)
+            SABnzbdClient(client(apiKey = "old"), engine).testConnection()
+            SABnzbdClient(client(apiKey = "new"), engine).testConnection()
+
+            assertEquals(listOf<String?>("old", "new"), seenKeys)
+        }
+
+    @Test
+    fun testConnectionReturnsErrorOnUnauthorized() =
+        runTest {
+            val mockEngine =
+                MockEngine { _ ->
+                    respond(content = "unauthorized", status = HttpStatusCode.Unauthorized)
+                }
+
+            val result = SABnzbdClient(client(), httpClient(mockEngine)).testConnection()
+
+            assertTrue(result is NetworkResult.Error)
+            assertEquals(HttpStatusCode.Unauthorized.value, result.code)
+        }
+}

--- a/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/repository/DownloadClientManagerTest.kt
+++ b/shared/src/commonTest/kotlin/com/dnfapps/arrmatey/downloadclient/repository/DownloadClientManagerTest.kt
@@ -1,0 +1,189 @@
+package com.dnfapps.arrmatey.downloadclient.repository
+
+import com.dnfapps.arrmatey.arr.api.client.HttpClientFactory
+import com.dnfapps.arrmatey.database.EncryptedString
+import com.dnfapps.arrmatey.downloadclient.api.DownloadClientApi
+import com.dnfapps.arrmatey.downloadclient.database.DownloadClientDao
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClient
+import com.dnfapps.arrmatey.downloadclient.model.DownloadClientType
+import io.ktor.client.plugins.logging.Logger
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNotSame
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+class DownloadClientManagerTest {
+    private val fakeDao = FakeDownloadClientDao()
+    private val repository = DownloadClientRepository(fakeDao)
+    private val silentLogger =
+        object : Logger {
+            override fun log(message: String) = Unit
+        }
+    private val httpClientFactory = HttpClientFactory(Json { ignoreUnknownKeys = true }, silentLogger)
+
+    private fun client(
+        id: Long,
+        password: String = "pw",
+        apiKey: String = "",
+    ) = DownloadClient(
+        id = id,
+        type = DownloadClientType.QBittorrent,
+        label = "c$id",
+        url = "http://localhost:$id",
+        password = EncryptedString(password),
+        apiKey = EncryptedString(apiKey),
+    )
+
+    // The manager collects on its own Dispatchers.Default scope, so tests await state changes.
+    private suspend fun DownloadClientManager.awaitApis(
+        predicate: (Map<Long, DownloadClientApi>) -> Boolean,
+    ): Map<Long, DownloadClientApi> = withTimeout(5_000) { downloadClientApis.first(predicate) }
+
+    @Test
+    fun testAddingClientsCreatesApis(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+
+            fakeDao.emit(listOf(client(1), client(2)))
+            val apis = manager.awaitApis { it.keys == setOf(1L, 2L) }
+
+            assertNotNull(apis[1])
+            assertNotNull(apis[2])
+        }
+
+    @Test
+    fun testRemovingClientRemovesItsApi(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+            fakeDao.emit(listOf(client(1), client(2)))
+            manager.awaitApis { it.keys == setOf(1L, 2L) }
+
+            fakeDao.emit(listOf(client(1)))
+            val apis = manager.awaitApis { it.keys == setOf(1L) }
+
+            assertNull(apis[2])
+        }
+
+    @Test
+    fun testCredentialChangeRebuildsApi(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+            fakeDao.emit(listOf(client(id = 1, password = "old")))
+            val original = manager.awaitApis { 1L in it.keys }[1]
+            assertNotNull(original)
+
+            fakeDao.emit(listOf(client(id = 1, password = "new")))
+            val rebuilt = manager.awaitApis { it[1] !== original }[1]
+
+            assertNotNull(rebuilt)
+            assertNotSame(original, rebuilt)
+        }
+
+    @Test
+    fun testUnchangedClientKeepsSameApiInstance(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+            val unchanged = client(id = 1, password = "same")
+            fakeDao.emit(listOf(unchanged))
+            val first = manager.awaitApis { 1L in it.keys }[1]
+
+            fakeDao.emit(listOf(unchanged))
+            delay(50)
+            val second = manager.downloadClientApis.value[1]
+
+            assertNotNull(first)
+            assertSame(first, second)
+        }
+
+    @Test
+    fun testRefreshApiCreatesNewInstance(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+            fakeDao.emit(listOf(client(1)))
+            manager.awaitApis { 1L in it.keys }
+            val first = manager.getOrCreateApi(1)
+
+            val refreshed = manager.refreshApi(1)
+
+            assertNotNull(first)
+            assertNotNull(refreshed)
+            assertNotSame(first, refreshed)
+        }
+
+    @Test
+    fun testRefreshApiReturnsNullForUnknownId(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+
+            val api = manager.refreshApi(999)
+
+            assertNull(api)
+        }
+
+    @Test
+    fun testGetOrCreateApiReturnsCachedInstance(): Unit =
+        runBlocking {
+            val manager = DownloadClientManager(repository, httpClientFactory)
+            fakeDao.emit(listOf(client(1)))
+            manager.awaitApis { 1L in it.keys }
+
+            val a: DownloadClientApi? = manager.getOrCreateApi(1)
+            val b: DownloadClientApi? = manager.getOrCreateApi(1)
+
+            assertNotNull(a)
+            assertTrue(a === b)
+        }
+}
+
+private class FakeDownloadClientDao : DownloadClientDao {
+    private val clients = MutableStateFlow<List<DownloadClient>>(emptyList())
+
+    fun emit(list: List<DownloadClient>) {
+        clients.value = list
+    }
+
+    override fun observeAllDownloadClients(): Flow<List<DownloadClient>> = clients
+
+    override fun observeSelectedDownloadClient(): Flow<DownloadClient?> = MutableStateFlow(clients.value.firstOrNull { it.selected })
+
+    override suspend fun getDownloadClientById(id: Long): DownloadClient? = clients.value.firstOrNull { it.id == id }
+
+    override suspend fun getAllDownloadClients(): List<DownloadClient> = clients.value
+
+    override suspend fun insert(downloadClient: DownloadClient): Long = throw NotImplementedError()
+
+    override suspend fun delete(downloadClient: DownloadClient) = throw NotImplementedError()
+
+    override suspend fun update(downloadClient: DownloadClient): Int = throw NotImplementedError()
+
+    override suspend fun updateAll(downloadClients: List<DownloadClient>) = throw NotImplementedError()
+
+    override suspend fun findByUrl(url: String): Long? = null
+
+    override suspend fun findByLabel(label: String): Long? = null
+
+    override suspend fun findOtherByUrl(
+        url: String,
+        currentId: Long,
+    ): Long? = null
+
+    override suspend fun findOtherByLabel(
+        label: String,
+        currentId: Long,
+    ): Long? = null
+
+    override suspend fun unselectAll() = Unit
+
+    override suspend fun selectDownloadClient(id: Long) = Unit
+
+    override suspend fun ensureFirstSelectedIfNone() = Unit
+}


### PR DESCRIPTION
Add tests for auth and cache in download clients.

Related to https://github.com/owenlejeune/ArrMatey/issues/174
